### PR TITLE
Implement read action

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,8 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "syn 2.0.96",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2057,6 +2059,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2149,6 +2161,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -3331,6 +3349,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3347,14 +3376,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex",
  "serde",
  "serde_json",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
  "tracing-serde",
 ]
 

--- a/packages/by-macros/Cargo.toml
+++ b/packages/by-macros/Cargo.toml
@@ -17,8 +17,11 @@ quote = "1.0.38"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_urlencoded = "0.7.1"
 syn = { version = "2.0.96", features = ["full"] }
+tracing = "0.1.41"
+tracing-subscriber = "0.3.19"
 
 [dev-dependencies]
+tracing-subscriber = "0.3.19"
 rest-api = { version = "0.1.1", path = "../rest-api" }
 by-axum.workspace = true
 reqwest = "0.12.12"

--- a/packages/by-macros/README.md
+++ b/packages/by-macros/README.md
@@ -15,51 +15,75 @@ use serde::{Deserialize, Serialize};
 
 type Result<T> = std::result::Result<T, by_types::ApiError<String>>;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[api_model(base = "/topics/v1", iter_type=Vec)]
 pub struct Topic {
     #[api_model(summary)]
     pub id: String,
-    #[api_model(summary)]
+    #[api_model(summary, action = create)]
     pub title: String,
-    #[api_model(summary, queryable)]
+    #[api_model(summary, queryable, read_action = search_by, action = create, action_by_id = update)]
     pub description: String,
-    #[api_model(summary, queryable)]
+    #[api_model(summary, queryable, action_by_id = update)]
     pub status: i32,
-    #[api_model(summary)]
+    #[api_model(summary, read_action = [search_by, date_from])]
     pub created_at: i64,
+    pub is_liked: bool,
 
     pub updated_at: i64,
+    #[api_model(action_by_id = like, related = CommentRequest)]
+    #[api_model(action = comment, related = Comment)]
+    pub comments: Vec<Comment>,
+
+    #[api_model(action_by_id = update)]
     pub tags: Vec<String>,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Comment {
+    pub id: String,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CommentRequest {
+    pub comment_id: String,
+    pub is_liked: bool,
+}
 ```
 
 ### Expanded code
 
 ``` rust
-pub struct Topic {
-    #[api_model(summary)]
-    pub id: String,
-    #[api_model(summary)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
+pub enum TopicAction {
+    Create(TopicCreateRequest),
+    Comment(Comment),
+}
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
+pub struct TopicCreateRequest {
     pub title: String,
-    #[api_model(summary, queryable)]
     pub description: String,
-    #[api_model(summary, queryable)]
+}
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
+pub enum TopicByIdAction {
+    Like(CommentRequest),
+    Update(TopicUpdateRequest),
+}
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
+pub struct TopicUpdateRequest {
+    pub description: String,
     pub status: i32,
-    #[api_model(summary)]
-    pub created_at: i64,
-
-    pub updated_at: i64,
     pub tags: Vec<String>,
 }
-
-impl Topic {
-    pub fn get_client(endpoint: &str) -> TopicClient {
-        TopicClient { endpoint : endpoint.to_string() }
-    }
-}
-
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
 pub struct TopicSummary {
     pub id: String,
     pub title: String,
@@ -67,28 +91,82 @@ pub struct TopicSummary {
     pub status: i32,
     pub created_at: i64,
 }
-
+#[derive(Debug, Clone, Serialize, Deserialize, Default, Eq, PartialEq, by_macros::QueryDisplay)]
+#[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
 pub struct TopicQuery {
     pub size: usize,
     pub bookmark: Option<String>,
+    pub action: Option<TopicReadActionType>,
     pub description: Option<String>,
     pub status: Option<i32>,
+    pub created_at: Option<i64>,
 }
-
+impl TopicQuery {
+    pub fn new(size: usize) -> Self {
+        Self {
+            size,
+            ..Self::default()
+        }
+    }
+    pub fn with_bookmark(mut self, bookmark: String) -> Self {
+        self.bookmark = Some(bookmark);
+        self
+    }
+    pub fn with_description(mut self, description: String) -> Self {
+        self.description = Some(description);
+        self
+    }
+    pub fn with_status(mut self, status: i32) -> Self {
+        self.status = Some(status);
+        self
+    }
+    pub fn search_by(mut self, description: String, created_at: i64) -> Self {
+        self.description = Some(description);
+        self.created_at = Some(created_at);
+        self.action = Some(TopicReadActionType::SearchBy);
+        self
+    }
+    pub fn date_from(mut self, created_at: i64) -> Self {
+        self.created_at = Some(created_at);
+        self.action = Some(TopicReadActionType::DateFrom);
+        self
+    }
+}
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
+pub enum TopicReadActionType {
+    SearchBy,
+    DateFrom,
+}
+impl Topic {
+    pub fn get_client(endpoint: &str) -> TopicClient {
+        TopicClient {
+            endpoint: endpoint.to_string(),
+        }
+    }
+}
+#[derive(Debug, Clone, Serialize, Deserialize, Default, Eq, PartialEq)]
 pub struct TopicClient {
     pub endpoint: String,
 }
-
 impl TopicClient {
-    pub async fn query(&self, params:TopicQuery) -> crate::Result<Vec<TopicSummary>> {
+    pub async fn query(&self, params: TopicQuery) -> crate::Result<Vec<TopicSummary>> {
         let endpoint = format!("{}{}", self.endpoint, "/topics/v1");
         let query = format!("{}?{}", endpoint, params);
         rest_api::get(&query).await
     }
-
     pub async fn get(&self, id: &str) -> crate::Result<Topic> {
         let endpoint = format!("{}{}/{}", self.endpoint, "/topics/v1", id);
-        rest_api::get(& endpoint).await
+        rest_api::get(&endpoint).await
+    }
+    pub async fn act(&self, params: TopicAction) -> crate::Result<Topic> {
+        let endpoint = format!("{}{}/action", self.endpoint, "/topics/v1");
+        rest_api::post(&endpoint, params).await
+    }
+    pub async fn act_by_id(&self, id: &str, params: TopicByIdAction) -> crate::Result<Topic> {
+        let endpoint = format!("{}{}/{}/action", self.endpoint, "/topics/v1", id);
+        rest_api::post(&endpoint, params).await
     }
 }
 ```

--- a/packages/by-macros/README.md
+++ b/packages/by-macros/README.md
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 type Result<T> = std::result::Result<T, by_types::ApiError<String>>;
 
 #[derive(Serialize, Deserialize)]
-#[api_model(get = "/topics/v1/:id", list = "/topics/v1", iter_type=Vec)]
+#[api_model(base = "/topics/v1", iter_type=Vec)]
 pub struct Topic {
     #[api_model(summary)]
     pub id: String,

--- a/packages/by-macros/src/api_model.rs
+++ b/packages/by-macros/src/api_model.rs
@@ -1,15 +1,15 @@
 use convert_case::{Case, Casing};
 use proc_macro::TokenStream;
 use quote::quote;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use syn::{parse_macro_input, Attribute, Data, DeriveInput, Field, Fields, Meta};
 
 #[derive(Debug)]
 enum ActionType {
     Summary,
     Queryable,
-    Action(String),
-    ActionById(String),
+    Action(Vec<String>),
+    ActionById(Vec<String>),
     Related(String),
     ReadActions(Vec<String>),
 }
@@ -26,7 +26,6 @@ fn parse_action_attr(attr: &Attribute) -> Vec<ActionType> {
             let mut selected_action = ActionType::Summary;
             let mut selected_at = 0;
             let mut i = 0;
-            let mut open_read_actions = false;
 
             for nested in meta_list.tokens.clone() {
                 if let proc_macro2::TokenTree::Ident(iden) = nested {
@@ -40,17 +39,17 @@ fn parse_action_attr(attr: &Attribute) -> Vec<ActionType> {
                         }
                         "action" => {
                             selected_at = i;
-                            selected_action = ActionType::Action("".to_string());
+                            selected_action = ActionType::Action(vec![]);
                         }
                         "action_by_id" => {
                             selected_at = i;
-                            selected_action = ActionType::ActionById("".to_string());
+                            selected_action = ActionType::ActionById(vec![]);
                         }
                         "related" => {
                             selected_at = i;
                             selected_action = ActionType::Related("".to_string());
                         }
-                        "read_actions" => {
+                        "read_action" => {
                             selected_at = i;
                             selected_action = ActionType::ReadActions(vec![]);
                         }
@@ -58,13 +57,16 @@ fn parse_action_attr(attr: &Attribute) -> Vec<ActionType> {
                             if selected_at == (i - 2) {
                                 match &selected_action {
                                     ActionType::Action(_) => {
-                                        types.push(ActionType::Action(id.to_string()));
+                                        types.push(ActionType::Action(vec![id.to_string()]));
                                     }
                                     ActionType::ActionById(_) => {
-                                        types.push(ActionType::ActionById(id.to_string()));
+                                        types.push(ActionType::ActionById(vec![id.to_string()]));
                                     }
                                     ActionType::Related(_) => {
                                         types.push(ActionType::Related(id.to_string()));
+                                    }
+                                    ActionType::ReadActions(_) => {
+                                        types.push(ActionType::ReadActions(vec![id.to_string()]));
                                     }
                                     _ => {}
                                 }
@@ -72,6 +74,27 @@ fn parse_action_attr(attr: &Attribute) -> Vec<ActionType> {
                                 panic!("Unexpected attribute key: {}", id);
                             }
                         }
+                    }
+                } else if let proc_macro2::TokenTree::Group(group) = nested {
+                    let mut actions = vec![];
+                    for nested in group.stream() {
+                        if let proc_macro2::TokenTree::Ident(iden) = nested {
+                            let id = iden.to_string();
+                            actions.push(id);
+                        }
+                    }
+
+                    match &selected_action {
+                        ActionType::Action(_) => {
+                            types.push(ActionType::Action(actions));
+                        }
+                        ActionType::ActionById(_) => {
+                            types.push(ActionType::ActionById(actions));
+                        }
+                        ActionType::ReadActions(_) => {
+                            types.push(ActionType::ReadActions(actions));
+                        }
+                        _ => {}
                     }
                 }
 
@@ -119,6 +142,7 @@ pub fn api_model_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut queryable_fields = Vec::new();
     let mut action_names = HashMap::<String, ActionField>::new();
     let mut action_by_id_names = HashMap::<String, ActionField>::new();
+    let mut read_action_names = HashMap::<String, ActionField>::new();
 
     if let Fields::Named(named_fields) = fields {
         for field in &named_fields.named {
@@ -134,56 +158,82 @@ pub fn api_model_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
                         ActionType::Queryable => {
                             queryable_fields.push(field.clone());
                         }
-                        ActionType::Action(action_name) => {
-                            actions.push(ActionType::Action(action_name));
+                        ActionType::Action(action_names) => {
+                            actions.push(ActionType::Action(action_names));
                         }
-                        ActionType::ActionById(action_name) => {
-                            actions.push(ActionType::ActionById(action_name));
+                        ActionType::ActionById(action_names) => {
+                            actions.push(ActionType::ActionById(action_names));
                         }
                         ActionType::Related(st) => {
                             related = Some(st);
+                        }
+                        ActionType::ReadActions(action_names) => {
+                            actions.push(ActionType::ReadActions(action_names));
                         }
                     }
                 }
 
                 for action in actions {
                     match (related.clone(), action) {
-                        (Some(st), ActionType::Action(action_name)) => {
-                            action_names
-                                .entry(action_name)
-                                .or_insert_with(|| ActionField::Related(st));
+                        (Some(st), ActionType::Action(actions)) => {
+                            for action_name in actions {
+                                action_names
+                                    .entry(action_name)
+                                    .or_insert_with(|| ActionField::Related(st.clone()));
+                            }
                         }
-                        (Some(st), ActionType::ActionById(action_name)) => {
-                            action_by_id_names
-                                .entry(action_name)
-                                .or_insert_with(|| ActionField::Related(st));
+                        (Some(st), ActionType::ActionById(actions)) => {
+                            for action_name in actions {
+                                action_by_id_names
+                                    .entry(action_name)
+                                    .or_insert_with(|| ActionField::Related(st.clone()));
+                            }
                         }
-                        (None, ActionType::Action(action_name)) => {
-                            match action_names
-                                .entry(action_name)
-                                .or_insert_with(|| ActionField::Fields(vec![]))
-                            {
-                                ActionField::Fields(v) => {
-                                    v.push(field.clone());
-                                }
+                        (None, ActionType::Action(actions)) => {
+                            for action_name in actions {
+                                match action_names
+                                    .entry(action_name)
+                                    .or_insert_with(|| ActionField::Fields(vec![]))
+                                {
+                                    ActionField::Fields(v) => {
+                                        v.push(field.clone());
+                                    }
 
-                                _ => {
-                                    panic!("Action should have fields")
-                                }
-                            };
+                                    _ => {
+                                        panic!("Action should have fields")
+                                    }
+                                };
+                            }
                         }
-                        (None, ActionType::ActionById(action_name)) => {
-                            match action_by_id_names
-                                .entry(action_name)
-                                .or_insert_with(|| ActionField::Fields(vec![]))
-                            {
-                                ActionField::Fields(v) => {
-                                    v.push(field.clone());
-                                }
-                                _ => {
-                                    panic!("ActionById should have fields")
-                                }
-                            };
+                        (None, ActionType::ActionById(actions)) => {
+                            for action_name in actions {
+                                match action_by_id_names
+                                    .entry(action_name)
+                                    .or_insert_with(|| ActionField::Fields(vec![]))
+                                {
+                                    ActionField::Fields(v) => {
+                                        v.push(field.clone());
+                                    }
+                                    _ => {
+                                        panic!("ActionById should have fields")
+                                    }
+                                };
+                            }
+                        }
+                        (None, ActionType::ReadActions(actions)) => {
+                            for action_name in actions {
+                                match read_action_names
+                                    .entry(action_name)
+                                    .or_insert_with(|| ActionField::Fields(vec![]))
+                                {
+                                    ActionField::Fields(v) => {
+                                        v.push(field.clone());
+                                    }
+                                    _ => {
+                                        panic!("ActionById should have fields")
+                                    }
+                                };
+                            }
                         }
                         _ => {}
                     }
@@ -193,7 +243,7 @@ pub fn api_model_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
     }
 
     let summary_struct = generate_summary_struct(&struct_name, &summary_fields);
-    let query_struct = generate_query_struct(&struct_name, &queryable_fields);
+    let query_struct = generate_query_struct(&struct_name, &queryable_fields, &read_action_names);
     let action_struct = generate_action_struct(&struct_name, &action_names, "Action");
     let action_by_id_struct =
         generate_action_struct(&struct_name, &action_by_id_names, "ByIdAction");
@@ -216,6 +266,7 @@ pub fn api_model_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
         #query_struct
         #client_impl
     };
+    println!("{}", output.to_string());
 
     output.into()
 }
@@ -298,22 +349,133 @@ fn generate_query_struct(
     struct_name: &syn::Ident,
 
     queryable_fields: &[syn::Field],
+    read_actions: &HashMap<String, ActionField>,
 ) -> proc_macro2::TokenStream {
-    let query_fields = queryable_fields.iter().map(|field| {
+    let mut hashed_fields = HashSet::new();
+    let mut query_fields = vec![];
+    let mut query_builder_functions = vec![];
+
+    for field in queryable_fields {
         let field_name = &field.ident;
+        hashed_fields.insert(field_name.clone());
         let field_type = &field.ty;
-        quote! { pub #field_name: Option<#field_type>, }
-    });
+        query_fields.push(quote! { pub #field_name: Option<#field_type>, });
+        let function_name = syn::Ident::new(
+            &format!("with_{}", field_name.as_ref().unwrap()),
+            struct_name.span(),
+        );
+
+        query_builder_functions.push(quote! {
+            pub fn #function_name(mut self, #field_name: #field_type) -> Self {
+                self.#field_name = Some(#field_name);
+                self
+            }
+        });
+    }
+    let mut extended_query_fields = vec![];
+    let mut read_action_types = vec![];
+
+    for (read_action, fields) in read_actions {
+        let mut params = vec![];
+        let mut replace_expressions = vec![];
+
+        match fields {
+            ActionField::Fields(v) => {
+                for field in v {
+                    let field_name = &field.ident;
+                    let field_type = &field.ty;
+
+                    replace_expressions.push(quote! {
+                        self.#field_name = Some(#field_name);
+                    });
+                    params.push((field_name.clone(), field_type.clone()));
+                    if hashed_fields.contains(field_name) {
+                        continue;
+                    }
+                    extended_query_fields.push(quote! {
+                        pub #field_name: Option<#field_type>,
+                    });
+                }
+            }
+            _ => {
+                panic!("Related field should not be in queryable fields");
+            }
+        }
+
+        let read_action_name =
+            syn::Ident::new(&read_action.to_case(Case::Pascal), struct_name.span());
+        read_action_types.push(quote! { #read_action_name, });
+
+        let function_name = syn::Ident::new(&read_action.to_case(Case::Snake), struct_name.span());
+        let function_params = params.iter().map(|(field_name, field_type)| {
+            quote! { #field_name: #field_type, }
+        });
+        let read_action_enum_name = syn::Ident::new(
+            &format!("{}ReadActionType", struct_name),
+            struct_name.span(),
+        );
+
+        query_builder_functions.push(quote! {
+            pub fn #function_name(mut self, #(#function_params)*) -> Self {
+                #(#replace_expressions)*
+                self.action = Some(#read_action_enum_name::#read_action_name);
+                self
+            }
+        });
+    }
+
+    let (read_action_enum, read_action_type_field) = if read_action_types.len() > 0 {
+        let read_action_enum_name = syn::Ident::new(
+            &format!("{}ReadActionType", struct_name),
+            struct_name.span(),
+        );
+        (
+            quote! {
+                #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+                #[serde(rename_all = "kebab-case")]
+                #[cfg_attr(feature = "server", derive(JsonSchema, aide::OperationIo))]
+                pub enum #read_action_enum_name {
+                    #(#read_action_types)*
+                }
+            },
+            quote! {
+                pub action: Option<#read_action_enum_name>,
+            },
+        )
+    } else {
+        (quote! {}, quote! {})
+    };
+
     let query_name = syn::Ident::new(&format!("{}Query", struct_name), struct_name.span());
 
     quote! {
-        #[derive(Debug, Clone, Serialize, Deserialize, Default, Eq, PartialEq, by_macros::QueryDisplay)]
+        #[derive(Debug, Clone, Serialize, Deserialize, Default Eq, PartialEq, by_macros::QueryDisplay)]
         #[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
         pub struct #query_name {
             pub size: usize,
             pub bookmark: Option<String>,
+            #read_action_type_field
             #(#query_fields)*
+            #(#extended_query_fields)*
         }
+
+        impl #query_name {
+            pub fn new(size: usize) -> Self {
+                Self {
+                    size,
+                    ..Self::default(),
+                }
+            }
+
+            pub fn with_bookmark(mut self, bookmark: String) -> Self {
+                self.bookmark = Some(bookmark);
+                self
+            }
+
+            #(#query_builder_functions)*
+        }
+
+        #read_action_enum
     }
 }
 

--- a/packages/by-macros/src/api_model.rs
+++ b/packages/by-macros/src/api_model.rs
@@ -11,6 +11,7 @@ enum ActionType {
     Action(String),
     ActionById(String),
     Related(String),
+    ReadActions(Vec<String>),
 }
 
 /// Parse the attribute string and return the action type
@@ -25,6 +26,7 @@ fn parse_action_attr(attr: &Attribute) -> Vec<ActionType> {
             let mut selected_action = ActionType::Summary;
             let mut selected_at = 0;
             let mut i = 0;
+            let mut open_read_actions = false;
 
             for nested in meta_list.tokens.clone() {
                 if let proc_macro2::TokenTree::Ident(iden) = nested {
@@ -47,6 +49,10 @@ fn parse_action_attr(attr: &Attribute) -> Vec<ActionType> {
                         "related" => {
                             selected_at = i;
                             selected_action = ActionType::Related("".to_string());
+                        }
+                        "read_actions" => {
+                            selected_at = i;
+                            selected_action = ActionType::ReadActions(vec![]);
                         }
                         _ => {
                             if selected_at == (i - 2) {
@@ -258,6 +264,7 @@ fn generate_action_struct(
 
     quote! {
         #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
+        #[serde(rename_all = "snake_case")]
         #[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
         pub enum #action_name {
             #(#action_fields)*

--- a/packages/by-macros/tests/api_model.rs
+++ b/packages/by-macros/tests/api_model.rs
@@ -15,9 +15,9 @@ pub struct Topic {
     pub title: String,
     #[api_model(summary, queryable, action = create, action_by_id = update)]
     pub description: String,
-    #[api_model(summary, queryable, action_by_id = update)]
+    #[api_model(summary, queryable, read_action = date_from, action_by_id = update)]
     pub status: i32,
-    #[api_model(summary)]
+    #[api_model(summary, read_action = [data_from])]
     pub created_at: i64,
     pub is_liked: bool,
 
@@ -46,16 +46,20 @@ pub struct CommentRequest {
 #[test]
 fn test_macro_expansion() {
     let q = TopicQuery {
+        action: Some(TopicReadActionType::DateFrom),
         size: 10,
         bookmark: None,
         description: None,
         status: Some(1),
+        created_at: None,
     };
 
     assert_eq!(q.status, Some(1));
     assert_eq!(q.size, 10);
     assert_eq!(q.bookmark, None);
     assert_eq!(q.description, None);
+
+    let q = TopicQuery::new(10).with_bookmark("test");
 
     let summary = TopicSummary::default();
     assert_eq!(summary.id, "".to_string());

--- a/packages/by-macros/tests/api_model.rs
+++ b/packages/by-macros/tests/api_model.rs
@@ -13,11 +13,11 @@ pub struct Topic {
     pub id: String,
     #[api_model(summary, action = create)]
     pub title: String,
-    #[api_model(summary, queryable, action = create, action_by_id = update)]
+    #[api_model(summary, queryable, read_action = search_by, action = create, action_by_id = update)]
     pub description: String,
-    #[api_model(summary, queryable, read_action = date_from, action_by_id = update)]
+    #[api_model(summary, queryable, action_by_id = update)]
     pub status: i32,
-    #[api_model(summary, read_action = [data_from])]
+    #[api_model(summary, read_action = [search_by, date_from])]
     pub created_at: i64,
     pub is_liked: bool,
 
@@ -31,7 +31,6 @@ pub struct Topic {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-#[api_model(base = "/topics/v1/:id/comments", iter_type=Vec)]
 pub struct Comment {
     pub id: String,
     pub content: String,
@@ -59,7 +58,13 @@ fn test_macro_expansion() {
     assert_eq!(q.bookmark, None);
     assert_eq!(q.description, None);
 
-    let q = TopicQuery::new(10).with_bookmark("test");
+    let _q = TopicQuery::new(10)
+        .with_bookmark("test".to_string())
+        .search_by("test".to_string(), 0);
+
+    let q = TopicQuery::new(10)
+        .with_bookmark("test".to_string())
+        .date_from(1);
 
     let summary = TopicSummary::default();
     assert_eq!(summary.id, "".to_string());


### PR DESCRIPTION
## API Model
### Usage
- `crate::Result` must be declared.
- For using `ApiError` as result error type, you should implement `From<String>` into inner error type
- If you want to use fully customized error type, you should implement `From<reqwest::Error>`.

``` rust
#[cfg(feature = "server")]
use by_axum::aide;

use by_macros::api_model;
use serde::{Deserialize, Serialize};

type Result<T> = std::result::Result<T, by_types::ApiError<String>>;

#[derive(Clone, Serialize, Deserialize)]
#[api_model(base = "/topics/v1", iter_type=Vec)]
pub struct Topic {
    #[api_model(summary)]
    pub id: String,
    #[api_model(summary, action = create)]
    pub title: String,
    #[api_model(summary, queryable, read_action = search_by, action = create, action_by_id = update)]
    pub description: String,
    #[api_model(summary, queryable, action_by_id = update)]
    pub status: i32,
    #[api_model(summary, read_action = [search_by, date_from])]
    pub created_at: i64,
    pub is_liked: bool,

    pub updated_at: i64,
    #[api_model(action_by_id = like, related = CommentRequest)]
    #[api_model(action = comment, related = Comment)]
    pub comments: Vec<Comment>,

    #[api_model(action_by_id = update)]
    pub tags: Vec<String>,
}

#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
pub struct Comment {
    pub id: String,
    pub content: String,
}

#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
pub struct CommentRequest {
    pub comment_id: String,
    pub is_liked: bool,
}
```

### Expanded code

``` rust
#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
#[serde(rename_all = "snake_case")]
#[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
pub enum TopicAction {
    Create(TopicCreateRequest),
    Comment(Comment),
}
#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default, Eq, PartialEq)]
#[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
pub struct TopicCreateRequest {
    pub title: String,
    pub description: String,
}
#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
#[serde(rename_all = "snake_case")]
#[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
pub enum TopicByIdAction {
    Like(CommentRequest),
    Update(TopicUpdateRequest),
}
#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default, Eq, PartialEq)]
#[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
pub struct TopicUpdateRequest {
    pub description: String,
    pub status: i32,
    pub tags: Vec<String>,
}
#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default, Eq, PartialEq)]
#[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
pub struct TopicSummary {
    pub id: String,
    pub title: String,
    pub description: String,
    pub status: i32,
    pub created_at: i64,
}
#[derive(Debug, Clone, Serialize, Deserialize, Default, Eq, PartialEq, by_macros::QueryDisplay)]
#[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
pub struct TopicQuery {
    pub size: usize,
    pub bookmark: Option<String>,
    pub action: Option<TopicReadActionType>,
    pub description: Option<String>,
    pub status: Option<i32>,
    pub created_at: Option<i64>,
}
impl TopicQuery {
    pub fn new(size: usize) -> Self {
        Self {
            size,
            ..Self::default()
        }
    }
    pub fn with_bookmark(mut self, bookmark: String) -> Self {
        self.bookmark = Some(bookmark);
        self
    }
    pub fn with_description(mut self, description: String) -> Self {
        self.description = Some(description);
        self
    }
    pub fn with_status(mut self, status: i32) -> Self {
        self.status = Some(status);
        self
    }
    pub fn search_by(mut self, description: String, created_at: i64) -> Self {
        self.description = Some(description);
        self.created_at = Some(created_at);
        self.action = Some(TopicReadActionType::SearchBy);
        self
    }
    pub fn date_from(mut self, created_at: i64) -> Self {
        self.created_at = Some(created_at);
        self.action = Some(TopicReadActionType::DateFrom);
        self
    }
}
#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
#[serde(rename_all = "kebab-case")]
#[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
pub enum TopicReadActionType {
    SearchBy,
    DateFrom,
}
impl Topic {
    pub fn get_client(endpoint: &str) -> TopicClient {
        TopicClient {
            endpoint: endpoint.to_string(),
        }
    }
}
#[derive(Debug, Clone, Serialize, Deserialize, Default, Eq, PartialEq)]
pub struct TopicClient {
    pub endpoint: String,
}
impl TopicClient {
    pub async fn query(&self, params: TopicQuery) -> crate::Result<Vec<TopicSummary>> {
        let endpoint = format!("{}{}", self.endpoint, "/topics/v1");
        let query = format!("{}?{}", endpoint, params);
        rest_api::get(&query).await
    }
    pub async fn get(&self, id: &str) -> crate::Result<Topic> {
        let endpoint = format!("{}{}/{}", self.endpoint, "/topics/v1", id);
        rest_api::get(&endpoint).await
    }
    pub async fn act(&self, params: TopicAction) -> crate::Result<Topic> {
        let endpoint = format!("{}{}/action", self.endpoint, "/topics/v1");
        rest_api::post(&endpoint, params).await
    }
    pub async fn act_by_id(&self, id: &str, params: TopicByIdAction) -> crate::Result<Topic> {
        let endpoint = format!("{}{}/{}/action", self.endpoint, "/topics/v1", id);
        rest_api::post(&endpoint, params).await
    }
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Dependencies**
	- Added `tracing` and `tracing-subscriber` dependencies to the project.

- **API Model Improvements**
	- Enhanced action type handling to support multiple action names.
	- Added new read action capabilities for fields.
	- Simplified routing structure for API endpoints.
	- Introduced new structures for handling comments and topic requests.

- **Query Capabilities**
	- Expanded query options for `description` and `created_at` fields.
	- Introduced new read actions like `search_by` and `date_from`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->