### PR TITLE
feat(auth): add new Authorization enum with variants for different auth methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "by-axum"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "aide",
  "axum 0.8.1",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "rest-api"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "base64 0.22.1",
  "candid",

--- a/packages/by-axum/Cargo.toml
+++ b/packages/by-axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "by-axum"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 description = "Library satisfying Biyard API convention"
 license = "Apache-2.0"

--- a/packages/rest-api/Cargo.toml
+++ b/packages/rest-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rest-api"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Library for REST API"
 license = "Apache-2.0"

--- a/packages/rest-api/src/signature.rs
+++ b/packages/rest-api/src/signature.rs
@@ -6,7 +6,7 @@ use simple_asn1::{
 };
 use std::{fmt::Display, str::FromStr};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum SignatureAlgorithm {
     EdDSA,
 }
@@ -28,7 +28,7 @@ impl FromStr for SignatureAlgorithm {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Signature {
     pub signature: Vec<u8>,
     pub algorithm: SignatureAlgorithm,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Package Updates**
  - Updated `by-axum` package version from 0.2.8 to 0.2.9
  - Updated `rest-api` package version from 0.1.3 to 0.1.4

- **Authorization Improvements**
  - Introduced a new `Authorization` enum to enhance authorization handling
  - Added support for different authorization mechanisms

- **Code Enhancements**
  - Added equality traits to `SignatureAlgorithm` and `Signature` structs for improved comparability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->