### PR TITLE
fix(api_model_struct): remove LIMIT and OFFSET from where_and_stat

### DIFF
--- a/packages/by-macros/src/api_model_struct.rs
+++ b/packages/by-macros/src/api_model_struct.rs
@@ -1696,6 +1696,9 @@ impl ApiModel<'_> {
                 let count_query = if where_and_statements.is_empty() {
                     format!("{}", #qc)
                 } else {
+                    let re = regex::Regex::new(r"(?i)\s*LIMIT\s+\$\d+\s*(OFFSET\s+\$\d+)?").unwrap();
+                    let where_and_statements = re.replace(where_and_statements, "").to_string();
+
                     if where_and_statements.to_lowercase().starts_with("where") {
                         format!("{} {} {}", #qc, where_and_statements, #group_by)
                     } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the accuracy of record counts by ensuring filtering operations no longer include unintended constraints. This update provides users with more consistent and reliable count values when viewing data summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->