### PR TITLE
feat(translate): add VARIANT for enum iter Enum

### DIFF
--- a/packages/dioxus-translate-macro/src/lib.rs
+++ b/packages/dioxus-translate-macro/src/lib.rs
@@ -259,7 +259,6 @@ pub fn translate_derive(input: TokenStream) -> TokenStream {
     // Generate the implementation block for `translate`
     let gen = quote! {
         impl #enum_name {
-            pub const VARIANTS: &'static [Self] = &[ #(#enum_name::#idents),* ];
             pub fn translate(&self, lang: &dioxus_translate::Language) -> &'static str {
                 match lang {
                     dioxus_translate::Language::En => match self {
@@ -267,6 +266,11 @@ pub fn translate_derive(input: TokenStream) -> TokenStream {
                     },
                     #ko_arm
                 }
+            }
+
+            pub const VARIANTS: &'static [Self] = &[ #(#enum_name::#idents,)* ];
+            pub fn variants(lang: &dioxus_translate::Language) -> Vec<String> {
+                Self::VARIANTS.iter().map(|v| v.translate(&lang).to_string()).collect::<Vec<_>>()
             }
         }
 

--- a/packages/dioxus-translate-macro/tests/translate_derive.rs
+++ b/packages/dioxus-translate-macro/tests/translate_derive.rs
@@ -59,3 +59,28 @@ fn test_from_str() {
     // Test invalid input
     assert!(ProjectArea::from_str("invalid_field").is_err());
 }
+
+#[test]
+fn test_variants() {
+    assert_eq!(
+        ProjectArea::VARIANTS,
+        &[
+            ProjectArea::Economy,
+            ProjectArea::Society,
+            ProjectArea::Technology,
+        ],
+    );
+}
+
+#[test]
+fn test_fn_variants() {
+    println!("{:?}", ProjectArea::variants(&Language::Ko));
+    assert_eq!(
+        ProjectArea::variants(&Language::En),
+        vec!["Economy", "Society", "Technology"],
+    );
+    assert_eq!(
+        ProjectArea::variants(&Language::Ko),
+        vec!["경제", "사회", "기술"],
+    );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced translation capabilities with stricter checks on enumeration types, ensuring only valid unit variants are accepted.
  - Introduced a public constant that provides static access to all valid enum variants, offering a more streamlined and reliable interface for translation handling.
  - Added a new method to retrieve translations of enum variants based on the selected language.

- **Tests**
  - Introduced new tests to verify the correctness of enum variant listings and their translations in multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->