### PR TITLE
fix(api_model_struct): ensure primary key is of type i64

### DIFF
--- a/packages/by-macros/src/api_model_struct.rs
+++ b/packages/by-macros/src/api_model_struct.rs
@@ -92,7 +92,7 @@ impl ApiModel<'_> {
         let iter_type_tokens: proc_macro2::TokenStream = iter_type_with_summary.parse().unwrap();
         let parent_params = parent_ids.iter().map(|id| {
             let id = syn::Ident::new(id, struct_name.span());
-            quote! { #id: &str, }
+            quote! { #id: i64, }
         });
         let parent_names = parent_ids.iter().map(|id| {
             let id = syn::Ident::new(id, struct_name.span());
@@ -125,7 +125,7 @@ impl ApiModel<'_> {
                     rest_api::get(&query).await
                 }
 
-                pub async fn get(&self, #(#parent_params_for_get)* id: &str) -> crate::Result<#struct_name> {
+                pub async fn get(&self, #(#parent_params_for_get)* id: i64) -> crate::Result<#struct_name> {
                     let path = format!(#base_endpoint_lit, #(#parent_names_for_get)*);
                     let endpoint = format!("{}{}/{}", self.endpoint, path, id);
                     rest_api::get(&endpoint).await
@@ -157,7 +157,7 @@ impl ApiModel<'_> {
         let base_endpoint_lit = syn::LitStr::new(base_endpoint, struct_name.span());
         let parent_params = parent_ids.iter().map(|id| {
             let id = syn::Ident::new(id, struct_name.span());
-            quote! { #id: &str, }
+            quote! { #id: i64, }
         });
         let parent_names = parent_ids.iter().map(|id| {
             let id = syn::Ident::new(id, struct_name.span());
@@ -383,7 +383,7 @@ impl ApiModel<'_> {
         let param_name = syn::Ident::new(&format!("{}Param", struct_name), struct_name.span());
         let parent_params = parent_ids.iter().map(|id| {
             let id = syn::Ident::new(id, struct_name.span());
-            quote! { #id: &str, }
+            quote! { #id: i64, }
         });
         let parent_names = parent_ids.iter().map(|id| {
             let id = syn::Ident::new(id, struct_name.span());
@@ -836,7 +836,7 @@ impl ApiModel<'_> {
                 .map(|(field_name, _)| quote! { #field_name: Some(#field_name), });
             let parent_params = parent_ids.iter().map(|id| {
                 let id = syn::Ident::new(id, struct_name.span());
-                quote! { #id: &str, }
+                quote! { #id: i64, }
             });
             let parent_names = parent_ids.iter().map(|id| {
                 let id = syn::Ident::new(id, struct_name.span());
@@ -986,7 +986,7 @@ impl ApiModel<'_> {
         let base_endpoint_lit = syn::LitStr::new(base_endpoint, struct_name.span());
         let parent_params = parent_ids.iter().map(|id| {
             let id = syn::Ident::new(id, struct_name.span());
-            quote! { #id: &str, }
+            quote! { #id: i64, }
         });
         let parent_names = parent_ids.iter().map(|id| {
             let id = syn::Ident::new(id, struct_name.span());

--- a/packages/by-macros/src/api_model_struct.rs
+++ b/packages/by-macros/src/api_model_struct.rs
@@ -2825,11 +2825,7 @@ END AS {}"#,
                             r#"
 COALESCE(
     json_agg(
-        jsonb_set(
-            to_jsonb(f),
-            '{{{{id}}}}',
-            to_jsonb(f.id::TEXT)
-        )
+        to_jsonb(f),
     ) FILTER (WHERE f.id IS NOT NULL), '[]'
 ) AS {}
 "#,
@@ -3574,6 +3570,12 @@ impl ApiField {
 
         let f = super::sql_model::parse_field_attr(field);
         let primary_key = f.attrs.contains_key(&SqlAttributeKey::PrimaryKey);
+        if primary_key {
+            if rust_type.as_str() != "i64" {
+                panic!("primary key must be i64 type");
+            }
+        }
+
         let version = match f.attrs.get(&SqlAttributeKey::Version) {
             Some(SqlAttribute::Version(v)) => Some(v.to_string()),
             _ => None,

--- a/packages/by-macros/src/api_model_struct.rs
+++ b/packages/by-macros/src/api_model_struct.rs
@@ -2477,7 +2477,7 @@ impl<'a> ApiModel<'a> {
 
         let mut base = String::new();
         let mut parent_ids = Vec::new();
-        let mut iter_type = "Vec".to_string();
+        let mut iter_type = "by_types::QueryResponse".to_string();
         let mut read_action_names = IndexMap::<String, ActionField>::new();
         let actions = attr
             .to_string()

--- a/packages/by-macros/src/api_model_struct.rs
+++ b/packages/by-macros/src/api_model_struct.rs
@@ -2827,9 +2827,7 @@ END AS {}"#,
                         Some(format!(
                             r#"
 COALESCE(
-    json_agg(
-        to_jsonb(f),
-    ) FILTER (WHERE f.id IS NOT NULL), '[]'
+    json_agg(to_jsonb(f)) FILTER (WHERE f.id IS NOT NULL), '[]'
 ) AS {}
 "#,
                             bound_name

--- a/packages/by-macros/tests/action_by_id_empty_param.rs
+++ b/packages/by-macros/tests/action_by_id_empty_param.rs
@@ -40,7 +40,7 @@ mod empty_param_tests {
     #[tokio::test]
     async fn test_action_by_id_empty_param() {
         let cli = ActionEmptyParamModel::get_client("test");
-        cli.delete("0");
+        cli.delete(0);
 
         cli.no_param();
         cli.empty();
@@ -70,7 +70,7 @@ mod empty_param_tests {
 
         let res = repo
             .update(
-                &res.id,
+                res.id,
                 ActionEmptyParamModelRepositoryUpdateRequest {
                     name: Some("test".to_string()),
                 },
@@ -82,7 +82,7 @@ mod empty_param_tests {
 
         let res = repo
             .update(
-                &res.id,
+                res.id,
                 ActionEmptyParamModelRepositoryUpdateRequest::new().with_name("test-2".to_string()),
             )
             .await;
@@ -91,7 +91,7 @@ mod empty_param_tests {
         assert_eq!(res.name, "test-2".to_string());
 
         let id = res.id.clone();
-        let res = repo.delete(&res.id).await;
+        let res = repo.delete(res.id).await;
         assert_eq!(res.is_ok(), true);
 
         let res = repo

--- a/packages/by-macros/tests/action_by_id_empty_param.rs
+++ b/packages/by-macros/tests/action_by_id_empty_param.rs
@@ -27,7 +27,7 @@ mod empty_param_tests {
     #[api_model(base = "/models", table = action_empty_params, iter_type=QueryResponse, action_by_id = delete, action = [no_param, empty])]
     pub struct ActionEmptyParamModel {
         #[api_model(summary, primary_key, read_action = find_by_id)]
-        pub id: String,
+        pub id: i64,
         #[api_model(summary, auto = [insert])]
         pub created_at: i64,
         #[api_model(summary, auto = [insert, update])]

--- a/packages/by-macros/tests/api_model.rs
+++ b/packages/by-macros/tests/api_model.rs
@@ -60,14 +60,14 @@ pub struct Comment {
     pub updated_at: i64,
 
     #[api_model(many_to_one = topics, foreign_key = id, foreign_key_type = TEXT)]
-    pub topic_id: String,
+    pub topic_id: i64,
 }
 
 #[cfg(not(feature = "server"))]
 #[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
 pub struct CommentRequest {
-    pub comment_id: String,
+    pub comment_id: i64,
     pub is_liked: bool,
 }
 
@@ -115,7 +115,7 @@ mod normal {
         );
 
         let summary = TopicSummary::default();
-        assert_eq!(summary.id, "".to_string());
+        assert_eq!(summary.id, 0);
         assert_eq!(summary.title, "".to_string());
         assert_eq!(summary.description, "".to_string());
         assert_eq!(summary.status, 0);
@@ -140,28 +140,28 @@ mod normal {
         let create_request = TopicAction::Create(create_request);
         let update_request = TopicByIdAction::Update(update_request);
         let like_request = TopicByIdAction::Like(CommentRequest {
-            comment_id: "1".to_string(),
+            comment_id: 1,
             is_liked: true,
         });
         let comment_request = TopicAction::Comment(Comment {
-            id: "1".to_string(),
+            id: 1,
             content: "content".to_string(),
             updated_at: 0,
-            topic_id: "1".to_string(),
+            topic_id: 1,
         });
 
         let cli = Topic::get_client("");
-        let _ = cli.get("1");
+        let _ = cli.get(1);
         let _ = cli.query(q);
         let _ = cli.act(create_request);
         let _ = cli.act(comment_request);
-        let _ = cli.act_by_id("1", update_request);
-        let _ = cli.act_by_id("1", like_request);
+        let _ = cli.act_by_id(1, update_request);
+        let _ = cli.act_by_id(1, like_request);
         let _ = cli.user_info("wallet".to_string(), "email".to_string(), 1);
         let _ = cli.check_email("email".to_string());
         // let _ = cli.search_by("test".to_string(), 0);
         let _ = cli.create("title".to_string(), "description".to_string());
-        let _ = cli.update("id", "description".to_string(), 1, vec!["tag".to_string()]);
+        let _ = cli.update(1, "description".to_string(), 1, vec!["tag".to_string()]);
         let _ = cli.search_by(
             1,
             Some("bookmark".to_string()),
@@ -174,13 +174,13 @@ mod normal {
     #[test]
     fn test_macro_expansion_comment() {
         let cli = Comment::get_client("");
-        let _ = cli.get("topic-id", "comment-id");
-        let _ = cli.query("topic-id", CommentQuery::new(10));
-        let _ = cli.act("topic-id", CommentAction::Comment("content".to_string()));
-        let _ = cli.comment("topic-id", "content".to_string());
-        let _ = cli.search_by("topic-id", "content".to_string());
-        let _ = cli.update("topic-id", "comment-id", 100);
-        let _ = cli.act_by_id("topic-id", "comment-id", CommentByIdAction::Update(100));
+        let _ = cli.get(1, 1);
+        let _ = cli.query(1, CommentQuery::new(10));
+        let _ = cli.act(1, CommentAction::Comment("content".to_string()));
+        let _ = cli.comment(1, "content".to_string());
+        let _ = cli.search_by(1, "content".to_string());
+        let _ = cli.update(1, 1, 100);
+        let _ = cli.act_by_id(1, 1, CommentByIdAction::Update(100));
     }
 }
 

--- a/packages/by-macros/tests/api_model.rs
+++ b/packages/by-macros/tests/api_model.rs
@@ -53,7 +53,7 @@ pub struct Topic {
 #[cfg(not(feature = "server"))]
 #[api_model(base = "/topics/v1/:topic-id/comments", iter_type=QueryResponse)]
 pub struct Comment {
-    pub id: String,
+    pub id: i64,
     #[api_model(action = comment, related = String, read_action = search_by)]
     pub content: String,
     #[api_model(action_by_id = update, related = i64)]
@@ -196,7 +196,7 @@ mod server_tests {
     #[api_model(base = "/users/v1", read_action = user_info, table = test_users, iter_type=QueryResponse)]
     pub struct User {
         #[api_model(primary_key)]
-        pub id: String,
+        pub id: i64,
         #[api_model(auto = insert)]
         pub created_at: u64,
         #[api_model(auto = [insert, update])]
@@ -250,7 +250,7 @@ $$ LANGUAGE plpgsql;
     #[test]
     fn test_macro_expansion_user() {
         let _ = User {
-            id: "id".to_string(),
+            id: 1,
             created_at: 0,
             updated_at: 0,
             principal: "principal".to_string(),

--- a/packages/by-macros/tests/api_model.rs
+++ b/packages/by-macros/tests/api_model.rs
@@ -23,7 +23,7 @@ impl<T> From<(Vec<T>, i64)> for QueryResponse<T> {
 #[api_model(base = "/topics/v1", iter_type=QueryResponse, table = topics)] // rename is supported but usually use default(snake_case)
 pub struct Topic {
     #[api_model(summary, primary_key)]
-    pub id: String,
+    pub id: i64,
     #[api_model(read_action = user_info)]
     pub wallet_address: String,
     #[api_model(read_action = [check_email,user_info])]

--- a/packages/by-macros/tests/many_to_many_find_test.rs
+++ b/packages/by-macros/tests/many_to_many_find_test.rs
@@ -1,0 +1,126 @@
+#[cfg(feature = "server")]
+pub type Result<T> = std::result::Result<T, by_types::ApiError<String>>;
+
+#[cfg(feature = "server")]
+pub mod many_to_many_find_test {
+    #![allow(unused)]
+    use super::*;
+    use std::time::SystemTime;
+
+    #[cfg(feature = "server")]
+    use by_axum::aide;
+    use by_macros::api_model;
+
+    #[api_model(base = "/auth/v1", action = [signup(code = String), reset(code = String)], read_action = refresh, table = users_mtm_test)]
+    pub struct User {
+        #[api_model(primary_key, read_action = find_by_id)]
+        pub id: i64,
+        #[api_model(auto = [insert])]
+        pub created_at: i64,
+        #[api_model(auto = [insert, update])]
+        pub updated_at: i64,
+        #[api_model(action = [signup, login, reset], unique, read_action = [get_user, find_by_email])]
+        pub email: String,
+        #[api_model(action = [signup, login, reset], read_action = get_user)]
+        pub password: String,
+
+        #[api_model(many_to_many = organization_members_mtm_test, foreign_table_name = organizations_mtm_test, foreign_primary_key = org_id, foreign_reference_key = user_id)]
+        #[serde(default)]
+        pub orgs: Vec<Organization>,
+    }
+    #[api_model(base = "/organizations/v2", table = organizations_mtm_test)]
+    pub struct Organization {
+        #[api_model(summary, primary_key, read_action = find_by_id)]
+        pub id: i64,
+        #[api_model(summary, auto = [insert])]
+        pub created_at: i64,
+        #[api_model(summary, auto = [insert, update])]
+        pub updated_at: i64,
+
+        #[api_model(summary)]
+        pub name: String,
+        #[api_model(many_to_many = organization_members_mtm_test, foreign_table_name = users, foreign_primary_key = user_id, foreign_reference_key = org_id)]
+        #[serde(default)]
+        pub users: Vec<User>,
+    }
+    #[api_model(base = "/members/v2", table = organization_members_mtm_test)]
+    pub struct OrganizationMember {
+        #[api_model(summary, primary_key)]
+        pub id: i64,
+        #[api_model(summary, auto = [insert])]
+        pub created_at: i64,
+        #[api_model(summary, auto = [insert, update])]
+        pub updated_at: i64,
+
+        #[api_model(many_to_one = users_mtm_test)]
+        pub user_id: i64,
+        #[api_model(many_to_one = organizations_mtm_test)]
+        pub org_id: i64,
+
+        #[api_model(summary, nullable)]
+        pub name: String,
+        #[api_model(summary)]
+        pub contact: Option<String>,
+    }
+
+    #[tokio::test]
+    async fn test_many_to_many_tests() {
+        let pool: sqlx::Pool<sqlx::Postgres> = sqlx::postgres::PgPoolOptions::new()
+            .max_connections(5)
+            .connect(
+                option_env!("DATABASE_URL")
+                    .unwrap_or("postgres://postgres:postgres@localhost:5432/test"),
+            )
+            .await
+            .unwrap();
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let email = format!("{}@example.com", now);
+        let password = "password".to_string();
+        let org_name = format!("org-{}", now);
+        let member_name = format!("member-{}", now);
+        let contact = Some("contact".to_string());
+
+        let u = User::get_repository(pool.clone());
+        let o = Organization::get_repository(pool.clone());
+        let m = OrganizationMember::get_repository(pool.clone());
+
+        u.create_this_table().await;
+        o.create_this_table().await;
+        m.create_this_table().await;
+
+        u.create_table().await;
+        o.create_table().await;
+        m.create_table().await;
+
+        let user = u.insert(email.clone(), password.clone()).await.unwrap();
+        let org = o.insert(org_name.clone()).await.unwrap();
+        let m1 = m
+            .insert(user.id, org.id, member_name.clone(), contact.clone())
+            .await
+            .unwrap();
+
+        let user = u
+            .find_one(&UserReadAction::new().find_by_id(user.id))
+            .await
+            .unwrap();
+
+        assert_eq!(user.orgs.len(), 1);
+
+        let org = o.insert(format!("{}2", org_name.clone())).await.unwrap();
+        let m1 = m
+            .insert(user.id, org.id, member_name.clone(), contact.clone())
+            .await
+            .unwrap();
+
+        let user = u
+            .find_one(&UserReadAction::new().find_by_id(user.id))
+            .await
+            .unwrap();
+
+        assert_eq!(user.orgs.len(), 2);
+    }
+}

--- a/packages/by-macros/tests/panel_v2.rs
+++ b/packages/by-macros/tests/panel_v2.rs
@@ -28,7 +28,7 @@ mod empty_param_tests {
     #[api_model(base = "organizations/v2/:org-id/panels", table = panels, iter_type=QueryResponse)]
     pub struct PanelV2 {
         #[api_model(summary, primary_key, action = delete, read_action = [get_panel, find_by_id])]
-        pub id: String,
+        pub id: i64,
         #[api_model(summary, auto = insert)]
         pub created_at: i64,
         #[api_model(auto = [insert, update])]
@@ -39,6 +39,6 @@ mod empty_param_tests {
         #[api_model(summary, action = [create], action_by_id = update)]
         pub user_count: u64,
         #[api_model(summary, many_to_one = organizations)]
-        pub org_id: String,
+        pub org_id: i64,
     }
 }

--- a/packages/by-macros/tests/server_user_org_model.rs
+++ b/packages/by-macros/tests/server_user_org_model.rs
@@ -127,9 +127,7 @@ $$ LANGUAGE plpgsql;
         let user = user.unwrap();
 
         let name = "org".to_string();
-        let res = o
-            .insert_with_dependency(user.id.parse().unwrap(), name.to_string())
-            .await;
+        let res = o.insert_with_dependency(user.id, name.to_string()).await;
 
         assert!(res.is_ok(), "{:?}", res);
 
@@ -144,9 +142,7 @@ $$ LANGUAGE plpgsql;
         assert_eq!(found_user.orgs.len(), 1);
         assert_eq!(found_user.orgs[0].name, name);
 
-        let res = o
-            .insert_with_dependency(user.id.parse().unwrap(), name.to_string())
-            .await;
+        let res = o.insert_with_dependency(user.id, name.to_string()).await;
         assert!(res.is_ok(), "{:?}", res);
 
         let res = u

--- a/packages/by-macros/tests/server_user_org_model.rs
+++ b/packages/by-macros/tests/server_user_org_model.rs
@@ -27,7 +27,7 @@ mod server_tests {
     #[api_model(base = "/auth/v1", action = [signup(code = String), reset(code = String)], table = uo_users, iter_type=QueryResponse)]
     pub struct User {
         #[api_model(primary_key)]
-        pub id: String,
+        pub id: i64,
         #[api_model(auto = insert)]
         pub created_at: i64,
         #[api_model(auto = [insert, update])]
@@ -45,7 +45,7 @@ mod server_tests {
     #[api_model(base = "/auth/v1/organizations", table = uo_organizations, iter_type=QueryResponse)]
     pub struct Organization {
         #[api_model(summary, primary_key)]
-        pub id: String,
+        pub id: i64,
         #[api_model(summary, auto = insert)]
         pub created_at: i64,
         #[api_model(summary, auto = [insert, update])]

--- a/packages/by-macros/tests/summary_model_base_sql.rs
+++ b/packages/by-macros/tests/summary_model_base_sql.rs
@@ -28,7 +28,7 @@ pub mod summary_model_base_sql_tests {
     #[api_model(base = "/models", table = summary_base_sql, iter_type=QueryResponse)]
     pub struct SummaryTest {
         #[api_model(summary, primary_key, read_action = find_by_id)]
-        pub id: String,
+        pub id: i64,
         #[api_model(summary, auto = [insert])]
         pub created_at: i64,
         #[api_model(summary, auto = [insert, update])]

--- a/packages/by-macros/tests/survey_model.rs
+++ b/packages/by-macros/tests/survey_model.rs
@@ -21,7 +21,7 @@ pub type Result<T> = std::result::Result<T, by_types::ApiError<String>>;
 #[api_model(base = "/public-surveys/v1/questions", table = questions, iter_type=QueryResponse)]
 pub struct PublicSurveyQuestion {
     #[api_model(primary_key)]
-    pub id: String,
+    pub id: i64,
     #[api_model(summary, auto = [insert])]
     pub created_at: i64,
     #[api_model(summary, auto = [insert, update])]

--- a/packages/by-macros/tests/survey_v2.rs
+++ b/packages/by-macros/tests/survey_v2.rs
@@ -27,7 +27,7 @@ mod empty_param_tests {
     #[api_model(base = "/organizations/v2/:org-id/surveys", table = surveys, iter_type=QueryResponse)]
     pub struct SurveyV2 {
         #[api_model(summary, primary_key, read_action = find_by_id)]
-        pub id: String,
+        pub id: i64,
         #[api_model(summary, auto = [insert])]
         pub created_at: i64,
         #[api_model(summary, auto = [insert, update])]
@@ -49,7 +49,7 @@ mod empty_param_tests {
         #[api_model(summary, action = create)]
         pub quotes: i64,
         #[api_model(summary, queryable, many_to_one = organizations)]
-        pub org_id: String,
+        pub org_id: i64,
         #[api_model(action = create, type = JSONB, version = v0.1)]
         pub questions: Vec<Question>,
         // #[api_model(summary, one_to_many= responses, aggregator = count)]

--- a/packages/by-macros/tests/topic_server_model.rs
+++ b/packages/by-macros/tests/topic_server_model.rs
@@ -42,17 +42,17 @@ mod server_tests {
     #[api_model(base = "/topics/v1/:topic-id/votes", table = votes, iter_type=QueryResponse)]
     pub struct Vote {
         #[api_model(summary, primary_key)]
-        pub id: String,
+        pub id: i64,
         #[api_model(summary, auto = [insert])]
         pub created_at: i64,
         #[api_model(summary, auto = [insert, update])]
         pub updated_at: i64,
 
         #[api_model(many_to_one = topics)]
-        pub topic_id: String,
+        pub topic_id: i64,
 
         #[api_model(many_to_one = users)]
-        pub user_id: String,
+        pub user_id: i64,
 
         #[api_model(summary, action = support)]
         pub amount: i64,
@@ -68,7 +68,7 @@ mod server_tests {
     #[api_model(base = "/users/v1", read_action = user_info, table = users, iter_type=QueryResponse)]
     pub struct User {
         #[api_model(primary_key)]
-        pub id: String,
+        pub id: i64,
         #[api_model(auto = insert)]
         pub created_at: u64,
         #[api_model(auto = [insert, update])]
@@ -94,7 +94,7 @@ mod server_tests {
     #[api_model(base = "/topics/v1", read_action = [get_topic] , table = topics, iter_type=QueryResponse)]
     pub struct Topic {
         #[api_model(summary, primary_key)]
-        pub id: String,
+        pub id: i64,
         #[api_model(summary, auto = [insert])]
         pub created_at: i64,
         #[api_model(summary, auto = [insert, update])]

--- a/packages/by-macros/tests/update_into_test.rs
+++ b/packages/by-macros/tests/update_into_test.rs
@@ -28,7 +28,7 @@ pub mod update_into_tests {
     #[api_model(base = "/models", table = upinto, iter_type=QueryResponse)]
     pub struct UpdateInto {
         #[api_model(summary, primary_key, read_action = find_by_id)]
-        pub id: String,
+        pub id: i64,
         #[api_model(summary, auto = [insert])]
         pub created_at: i64,
         #[api_model(summary, auto = [insert, update])]

--- a/packages/by-macros/tests/update_into_test.rs
+++ b/packages/by-macros/tests/update_into_test.rs
@@ -78,7 +78,7 @@ pub mod update_into_tests {
             description: new_desc.clone(),
         });
 
-        repo.update(&doc.id, req.into()).await.unwrap();
+        repo.update(doc.id, req.into()).await.unwrap();
 
         let res: UpdateInto = repo
             .find_one(&UpdateIntoReadAction::new().find_by_id(doc.id.clone()))
@@ -90,7 +90,7 @@ pub mod update_into_tests {
         assert_eq!(res.status, status);
 
         let req = UpdateIntoByIdAction::UpdateStatus(UpdateIntoUpdateStatusRequest { status: 2 });
-        repo.update(&doc.id, req.into()).await.unwrap();
+        repo.update(doc.id, req.into()).await.unwrap();
         let res: UpdateInto = repo
             .find_one(&UpdateIntoReadAction::new().find_by_id(doc.id.clone()))
             .await
@@ -102,7 +102,7 @@ pub mod update_into_tests {
 
         let req = UpdateIntoByIdAction::UpdateStatus(UpdateIntoUpdateStatusRequest { status: 2 });
         let req: UpdateIntoRepositoryUpdateRequest = req.into();
-        repo.update(&doc.id, req.with_name(name.clone()))
+        repo.update(doc.id, req.with_name(name.clone()))
             .await
             .unwrap();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced validation for primary key fields to ensure they use the correct numeric type, preventing configuration errors and potential runtime issues.
  - Introduced a new module for testing many-to-many relationships, including user and organization associations.

- **Changes**
  - Updated multiple struct fields across various modules from `String` to `i64` for identifiers, improving consistency in data representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->