### PR TITLE
fix(by-macros): correct return type in derive_dioxus_controller function

### DIFF
--- a/packages/by-macros/src/lib.rs
+++ b/packages/by-macros/src/lib.rs
@@ -199,7 +199,7 @@ pub fn derive_dioxus_controller(input: TokenStream) -> TokenStream {
 
                     quote! {
                         pub fn #field_name(&self) -> std::result::Result<#t, RenderError> {
-                            self.#field_name.suspend()?()
+                            Ok(self.#field_name.suspend()?())
                         }
                     }
                 } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling for resource-related operations to ensure outcomes are consistently wrapped and returned correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->