### PR TITLE
feat(cdk-stack): add task execution role for ECS tasks

### DIFF
--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -314,10 +314,33 @@ export class CdkStack extends cdk.Stack {
         vpc,
       });
 
+      const taskExecutionRole = new iam.Role(this, "MyEcsTaskExecutionRole", {
+        assumedBy: new iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
+      });
+
+      taskExecutionRole.addManagedPolicy(
+        iam.ManagedPolicy.fromAwsManagedPolicyName(
+          "service-role/AmazonECSTaskExecutionRolePolicy",
+        ),
+      );
+
+      taskExecutionRole.addToPolicy(
+        new iam.PolicyStatement({
+          actions: [
+            "ecr:GetAuthorizationToken",
+            "ecr:BatchCheckLayerAvailability",
+            "ecr:GetDownloadUrlForLayer",
+            "ecr:BatchGetImage",
+          ],
+          resources: ["*"],
+        }),
+      );
+
       const taskDefinition = new TaskDefinition(this, "FargateTask", {
         compatibility: Compatibility.FARGATE,
         cpu: "256",
         memoryMiB: "512",
+        executionRole: taskExecutionRole,
       });
 
       const container = taskDefinition.addContainer("Container", {

--- a/packages/by-components/src/meta/mod.rs
+++ b/packages/by-components/src/meta/mod.rs
@@ -21,8 +21,6 @@ pub fn MetaSeoTemplate(
         if let Some(author) = author {
             document::Meta { name: "author", content: "{author}" }
         }
-        document::Meta { name: "robots", content: "{robots}" }
-        document::Link { rel: "canonical", href: "{canonical}" }
         document::Meta { property: "og:site_name", content: "{title}" }
         document::Meta { property: "og:url", content: "{url}" }
         document::Meta { property: "og:logo", content: "{logo_url}" }


### PR DESCRIPTION
Added a new IAM role for ECS task execution with necessary policies to the CDK stack. This role includes permissions for ECR actions and is assigned to the Fargate task definition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced ECS task execution by introducing a new execution role, providing improved security and access controls.
  - ECS tasks now securely interact with container registries, including fetching authorization tokens and verifying image layers for reliable operations.
  
- **Bug Fixes**
  - Removed unnecessary meta tags for "robots" and canonical links in the MetaSeoTemplate function, streamlining SEO handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->