### PR TITLE
feat(api_model_struct): add skip attribute to ApiField and deprecate find methods

### DIFF
--- a/packages/by-macros/src/api_model_struct.rs
+++ b/packages/by-macros/src/api_model_struct.rs
@@ -1890,6 +1890,9 @@ impl ApiModel<'_> {
                 .fields
                 .get(&f.to_string().to_case(self.rename))
                 .expect(&format!("Field not found: {}", f.to_string()));
+            if field.skip {
+                continue;
+            }
 
             let bind = field.bind();
 
@@ -1947,6 +1950,7 @@ impl ApiModel<'_> {
         let rt = &self.result_type;
 
         let output = quote! {
+            #[deprecated(note = "Use `query_builder()` instead.")]
             pub async fn find(&self, param: &#query_struct) -> #rt<#name> {
                 #declare_where_clause
                 #(#where_clause)*
@@ -2243,6 +2247,10 @@ impl ApiModel<'_> {
                 .get(&f.to_string().to_case(self.rename))
                 .expect(&format!("Field not found: {}", f.to_string()));
 
+            if field.skip {
+                continue;
+            }
+
             let bind = field.bind();
 
             binds.push(quote! {
@@ -2283,6 +2291,7 @@ impl ApiModel<'_> {
         let rt = &self.result_type;
 
         let output = quote! {
+            #[deprecated(note = "Use `query_builder()` instead.")]
             pub async fn find_one(&self, #(#aggregate_args)* param: &#read_action) -> #rt<#name> {
                 #for_where
                 query.push_str(" ");
@@ -2932,6 +2941,10 @@ impl ApiModel<'_> {
                 }
             });
             continue;
+        }
+
+        if option_condition.is_empty() {
+            return quote! {};
         }
 
         let name = syn::Ident::new(&self.name, proc_macro2::Span::call_site());
@@ -3602,6 +3615,7 @@ pub struct ApiField {
     pub unique: bool,
     pub auto: Vec<AutoOperation>,
     pub nullable: bool,
+    // omitted indicates if this field should be included in insert or not.
     pub omitted: bool,
     pub rust_type: String,
 
@@ -3615,6 +3629,8 @@ pub struct ApiField {
     pub version: Option<String>,
 
     pub aggregator: Option<Aggregator>,
+    // skip indicates if this field should be skipped for sql model or not.
+    pub skip: bool,
 
     // depends on struct derive
     pub rename: Case,
@@ -3909,6 +3925,9 @@ LEFT JOIN (
     }
 
     pub fn can_query(&self) -> bool {
+        if self.skip {
+            return false;
+        }
         if self.aggregator.is_some() {
             return true;
         }
@@ -3921,6 +3940,9 @@ LEFT JOIN (
     }
 
     pub fn should_return_in_insert(&self) -> bool {
+        if self.skip {
+            return false;
+        }
         match self.relation {
             Some(Relation::ManyToMany { .. }) => false,
             Some(Relation::OneToMany { .. }) => false,
@@ -3930,6 +3952,7 @@ LEFT JOIN (
 
     pub fn should_skip_inserting(&self) -> bool {
         self.omitted
+            || self.skip
             || self.auto.len() > 0
             || match self.relation {
                 Some(Relation::OneToMany { .. }) => true,
@@ -4130,6 +4153,9 @@ END $$;
     }
 
     fn create_field_query_line(&self) -> Option<String> {
+        if self.skip {
+            return None;
+        }
         let name = self.name.to_case(self.rename);
 
         let mut line = match &self.relation {
@@ -4452,6 +4478,8 @@ impl ApiField {
         }
 
         let f = super::sql_model::parse_field_attr(field);
+        let skip = f.attrs.contains_key(&SqlAttributeKey::Skip);
+
         let primary_key = f.attrs.contains_key(&SqlAttributeKey::PrimaryKey);
         if primary_key {
             if rust_type.as_str() != "i64" {
@@ -4603,6 +4631,7 @@ impl ApiField {
             related,
             version,
             aggregator,
+            skip,
 
             table,
             rename,

--- a/packages/by-macros/src/sql_model.rs
+++ b/packages/by-macros/src/sql_model.rs
@@ -77,6 +77,7 @@ pub enum SqlAttributeKey {
     SqlType,
     Relation,
     Unique,
+    Skip,
     Auto,
     Version,
     Nullable,
@@ -128,6 +129,7 @@ pub enum SqlAttribute {
         foreign_key: String,
     },
     Unique,
+    Skip,
     Auto(Vec<AutoOperation>),
     Version(String),
     Nullable,
@@ -185,6 +187,10 @@ pub fn parse_field_attr(field: &Field) -> SqlAttributes {
                             "unique" => {
                                 field_attrs.insert(SqlAttributeKey::Unique, SqlAttribute::Unique);
                             }
+                            "skip" => {
+                                field_attrs.insert(SqlAttributeKey::Skip, SqlAttribute::Skip);
+                            }
+
                             "type" => {
                                 opened = OpenedOffset::Type;
                             }


### PR DESCRIPTION
+ Added ~skip~ attribute to ~ApiField~ to allow skipping fields in SQL
+ Deprecated `find` and `find_one` functions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - **Flexible Field Handling:** Users can now flag specific fields to be omitted from processing, allowing for more customizable data modeling.
  - **Enhanced Query Options:** Direct query methods have been deprecated in favor of a builder-based approach, streamlining database interactions.
  - **Improved SQL Attribute Management:** The system now supports a new option for SQL attribute handling, further enhancing configuration flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->