### PR TITLE
fix(btracing): remove hardcoded toast header text

### DIFF
--- a/packages/btracing/src/lib.rs
+++ b/packages/btracing/src/lib.rs
@@ -57,7 +57,7 @@ pub fn ToastTracing(
                 div { class: "btracing-toast-content",
                     div { class: "btracing-toast-header",
                         {children}
-                        h3 { class: "btracing-toast-header-text", "Your app is being rebuilt." }
+                        h3 { class: "btracing-toast-header-text", "" }
                     }
                     if let Some(ToastMessage { ref message, .. }) = toast() {
                         p { class: "btracing-toast-msg", "{message}" }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Modified the toast notification display by removing a previously shown header message. This update offers a cleaner and more streamlined look, ensuring that users receive a more focused and less distracting alert experience. The change enhances visual clarity and overall interaction, improving the overall user experience by decluttering the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->