### PR TITLE
feat(api_model_struct): add reference_key to Relation enums

### DIFF
--- a/packages/by-axum/src/auth.rs
+++ b/packages/by-axum/src/auth.rs
@@ -65,7 +65,7 @@ pub async fn authorization_middleware(
     mut req: Request,
     next: Next,
 ) -> Result<Response<Body>, StatusCode> {
-    tracing::debug!("Authorization middleware");
+    tracing::debug!("Authorization middleware {:?}", req.uri());
     if let Some(auth_header) = req.headers().get(AUTHORIZATION) {
         if let Ok(auth_value) = auth_header.to_str() {
             let mut auth_value = auth_value.split_whitespace();
@@ -96,6 +96,7 @@ pub async fn authorization_middleware(
                 }
             };
 
+            tracing::debug!("Authorization: {:?}", ext);
             req.extensions_mut().insert(ext);
 
             return Ok(next.run(req).await);

--- a/packages/by-macros/src/api_model_struct.rs
+++ b/packages/by-macros/src/api_model_struct.rs
@@ -787,7 +787,7 @@ impl ApiModel<'_> {
                                 }
                             });
                                 quote! {
-                                    #[serde(deserialize_with = #fname_str)]
+                                    #[serde(deserialize_with = #fname_str, default)]
                                 }
                             }
                         };
@@ -1025,7 +1025,7 @@ impl ApiModel<'_> {
                     }
                 });
                     quote! {
-                        #[serde(deserialize_with = #fname_str)]
+                        #[serde(deserialize_with = #fname_str, default)]
                     }
                 }
             };
@@ -1104,6 +1104,7 @@ impl ApiModel<'_> {
                                     D: serde::Deserializer<'de>,
                                 {
                                     use serde::Deserialize;
+                                    tracing::debug!("Parsing field: {}", #fname_str);
 
                                     let s: Option<String> = Option::deserialize(deserializer)?;
                                     match s {
@@ -1117,7 +1118,7 @@ impl ApiModel<'_> {
                                 }
                             });
                                 quote! {
-                                    #[serde(deserialize_with = #fname_str)]
+                                    #[serde(deserialize_with = #fname_str, default)]
                                 }
                             }
                         };
@@ -1247,7 +1248,7 @@ impl ApiModel<'_> {
             #[serde(rename_all = "kebab-case")]
             #[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
             pub struct #query_name {
-                #[serde(deserialize_with = #size_fname_str)]
+                #[serde(deserialize_with = #size_fname_str, default)]
                 pub size: usize,
                 pub bookmark: Option<String>,
                 #read_action_type_field

--- a/packages/by-macros/src/api_model_struct.rs
+++ b/packages/by-macros/src/api_model_struct.rs
@@ -3865,12 +3865,8 @@ COALESCE(
 
     pub fn group_by(&self) -> Option<String> {
         match self.relation {
-            Some(Relation::ManyToMany {
-                ref reference_key, ..
-            }) => return Some(format!("GROUP BY p.{reference_key}")),
-            Some(Relation::OneToMany {
-                ref reference_key, ..
-            }) => return Some(format!("GROUP BY p.{reference_key}")),
+            Some(Relation::ManyToMany { .. }) => return Some(format!("GROUP BY p.id")),
+            Some(Relation::OneToMany { .. }) => return Some(format!("GROUP BY p.id")),
             _ => None,
         }
     }

--- a/packages/rest-api/src/lib.rs
+++ b/packages/rest-api/src/lib.rs
@@ -216,6 +216,7 @@ where
     T: serde::de::DeserializeOwned,
     E: serde::de::DeserializeOwned + From<reqwest::Error>,
 {
+    tracing::debug!("GET {}", url);
     let client = reqwest::Client::builder().build()?;
 
     let req = client.get(url);


### PR DESCRIPTION
Added a new field `reference_key` to the `Relation` enums in `api_model_struct.rs` and `sql_model.rs`. This change enhances the handling of reference keys in various relation types, improving query generation and group by functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced customizable reference keys for relationship queries, allowing for more precise data retrieval.
  - Enhanced query generation to leverage these keys for improved filtering, aggregation, and grouping of related data.
  - Added debug logging for GET requests and authorization middleware, improving observability and traceability of processes.

- **Bug Fixes**
  - Improved error handling during deserialization by implementing default values for missing fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->