### PR TITLE
Fix(by-macro)/"aggregate_args" bug

### DIFF
--- a/packages/by-macros/src/api_model_struct.rs
+++ b/packages/by-macros/src/api_model_struct.rs
@@ -2131,7 +2131,7 @@ impl ApiModel<'_> {
                 query
             }
 
-            pub fn query_builder(#(#aggregate_args)*) -> #query_builder {
+            pub fn query_builder(#(#aggregate_args),*) -> #query_builder {
                 let base_sql = format!(#q, #(#arg_names),*);
                 #query_builder::from(&base_sql, #group_by).with_count()
             }
@@ -2194,7 +2194,7 @@ impl ApiModel<'_> {
 
             #group_by
 
-            pub fn query_builder(#(#aggregate_args)*) -> #query_builder {
+            pub fn query_builder(#(#aggregate_args),*) -> #query_builder {
                 let base_sql = format!(#q, #(#arg_names),*);
                 let g = #name::group_by();
                 #query_builder::from(&base_sql, &g)
@@ -2283,7 +2283,7 @@ impl ApiModel<'_> {
         let rt = &self.result_type;
 
         let output = quote! {
-            pub async fn find_one(&self, #(#aggregate_args)* param: &#read_action) -> #rt<#name> {
+            pub async fn find_one(&self, #(#aggregate_args,)* param: &#read_action) -> #rt<#name> {
                 #for_where
                 query.push_str(" ");
                 query.push_str(#name::group_by().as_str());

--- a/packages/by-macros/tests/test_duplicate_exist_aggregators.rs
+++ b/packages/by-macros/tests/test_duplicate_exist_aggregators.rs
@@ -1,0 +1,183 @@
+#[cfg(feature = "server")]
+pub type Result<T> = std::result::Result<T, by_types::ApiError<String>>;
+
+#[cfg(feature = "server")]
+mod test_duplicate_exist_aggregators {
+    #![allow(unused)]
+    use super::*;
+    use by_axum::aide;
+    use by_macros::api_model;
+    use std::time::SystemTime;
+
+    #[api_model(base = "/", table = test_duplicate_aggregators_users)]
+    pub struct User {
+        #[api_model(primary_key)]
+        pub id: i64,
+        #[api_model(auto = [insert])]
+        pub created_at: i64,
+        #[api_model(auto = [insert, update])]
+        pub updated_at: i64,
+        #[api_model(summary, action = signup, unique)]
+        pub email: String,
+    }
+
+    #[api_model(base = "/", table = test_duplicate_aggregators_models)]
+    pub struct Model {
+        #[api_model(primary_key, read_action = find_by_id)]
+        pub id: i64,
+        #[api_model(auto = insert)]
+        pub created_at: i64,
+        #[api_model(auto = [insert, update])]
+        pub updated_at: i64,
+
+        #[api_model(summary)]
+        pub title: String,
+
+        #[api_model(summary, many_to_many = test_duplicate_aggregators_model_user_likes, table_name = test_duplicate_aggregators_users, foreign_primary_key = user_id, foreign_reference_key = model_id, aggregator = exist)]
+        pub liked: bool,
+
+        #[api_model(summary, many_to_many = test_duplicate_aggregators_model_user_follows, table_name = test_duplicate_aggregators_users, foreign_primary_key = user_id, foreign_reference_key = model_id, aggregator = exist)]
+        pub followed: bool,
+    }
+
+    #[api_model(base = "/", table = test_duplicate_aggregators_model_user_likes)]
+    pub struct ModelUserLikes {
+        #[api_model(summary, primary_key)]
+        pub id: i64,
+        #[api_model(summary, auto = [insert])]
+        pub created_at: i64,
+        #[api_model(summary, auto = [insert, update])]
+        pub updated_at: i64,
+
+        #[api_model(many_to_one = test_duplicate_aggregators_models)]
+        pub model_id: i64,
+        #[api_model(many_to_one = test_duplicate_aggregators_users)]
+        pub user_id: i64,
+    }
+
+    #[api_model(base = "/", table = test_duplicate_aggregators_model_user_follows)]
+    pub struct ModelMemberFollows {
+        #[api_model(summary, primary_key)]
+        pub id: i64,
+        #[api_model(summary, auto = [insert])]
+        pub created_at: i64,
+        #[api_model(summary, auto = [insert, update])]
+        pub updated_at: i64,
+
+        #[api_model(many_to_one = test_duplicate_aggregators_models)]
+        pub model_id: i64,
+        #[api_model(many_to_one = test_duplicate_aggregators_users)]
+        pub user_id: i64,
+    }
+
+    async fn db_setup(pool: &sqlx::Pool<sqlx::Postgres>) {
+        let query = r#"
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at := EXTRACT(EPOCH FROM now()); -- seconds
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+    "#;
+        sqlx::query(query).execute(pool).await.unwrap();
+
+        let query = r#"
+CREATE OR REPLACE FUNCTION set_created_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.created_at := EXTRACT(EPOCH FROM now()); -- seconds
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+    "#;
+
+        sqlx::query(query).execute(pool).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_user_org() {
+        use sqlx::{postgres::PgPoolOptions, Postgres};
+        let _ = tracing_subscriber::fmt::try_init();
+        let pool: sqlx::Pool<sqlx::Postgres> = sqlx::postgres::PgPoolOptions::new()
+            .max_connections(5)
+            .connect(
+                option_env!("DATABASE_URL")
+                    .unwrap_or("postgres://postgres:postgres@localhost:5432/test"),
+            )
+            .await
+            .unwrap();
+
+        db_setup(&pool).await;
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let user_repo = User::get_repository(pool.clone());
+        let model_repo = Model::get_repository(pool.clone());
+        let like_repo = ModelUserLikes::get_repository(pool.clone());
+        let follow_repo = ModelMemberFollows::get_repository(pool.clone());
+
+        user_repo.create_this_table().await;
+        model_repo.create_this_table().await;
+        like_repo.create_this_table().await;
+        follow_repo.create_this_table().await;
+
+        user_repo.create_related_tables().await;
+        model_repo.create_related_tables().await;
+        like_repo.create_related_tables().await;
+        follow_repo.create_related_tables().await;
+
+        let email = format!("{}@example.com", now);
+        let user = user_repo.insert(email.clone()).await;
+        assert!(user.is_ok(), "{:?}", user);
+        let user = user.unwrap();
+
+        let model = model_repo.insert("TEST 2".to_string()).await;
+        assert!(model.is_ok(), "{:?}", model);
+        let model = model.unwrap();
+
+        let model_user_likes = like_repo.insert(model.id, user.id).await;
+        assert!(model_user_likes.is_ok(), "{:?}", model_user_likes);
+        let r = model_repo
+            .find_one(user.id, &ModelReadAction::new().find_by_id(model.id))
+            .await;
+        assert!(r.is_ok(), "{:?}", r);
+        let r = r.unwrap();
+        assert_eq!(r.liked, true);
+        assert_eq!(r.followed, false);
+
+        let r: std::result::Result<Model, sqlx::Error> = Model::query_builder(user.id)
+            .id_equals(model.id)
+            .query()
+            .map(|r: sqlx::postgres::PgRow| {
+                use sqlx::Row;
+                r.into()
+            })
+            .fetch_one(&pool)
+            .await;
+        assert!(r.is_ok(), "{:?}", r);
+        let r = r.unwrap();
+        assert_eq!(r.liked, true);
+        assert_eq!(r.followed, false);
+
+        let model_user_followers = follow_repo.insert(model.id, user.id).await;
+
+        assert!(model_user_followers.is_ok(), "{:?}", model_user_followers);
+
+        let r: std::result::Result<Model, sqlx::Error> = Model::query_builder(user.id)
+            .id_equals(model.id)
+            .query()
+            .map(|r: sqlx::postgres::PgRow| {
+                use sqlx::Row;
+                r.into()
+            })
+            .fetch_one(&pool)
+            .await;
+        assert!(r.is_ok(), "{:?}", r);
+        let r = r.unwrap();
+        assert_eq!(r.liked, true);
+        assert_eq!(r.followed, true);
+    }
+}

--- a/packages/by-macros/tests/test_duplicate_exist_aggregators.rs
+++ b/packages/by-macros/tests/test_duplicate_exist_aggregators.rs
@@ -21,6 +21,7 @@ mod test_duplicate_exist_aggregators {
         pub email: String,
     }
 
+    // Note: when fields have duplicated foreign_primary_key(user_id, member_id) with exist aggregator.
     #[api_model(base = "/", table = test_duplicate_aggregators_models)]
     pub struct Model {
         #[api_model(primary_key, read_action = find_by_id)]

--- a/packages/by-macros/tests/test_multiple_exist_aggregators.rs
+++ b/packages/by-macros/tests/test_multiple_exist_aggregators.rs
@@ -33,7 +33,7 @@ mod test_multiple_exist_aggeregators {
         pub name: String,
     }
 
-    // Note: When having the same foreign_primary_key "user_id".
+    // Note: when fields have multiple foreign_primary_key(user_id) with exist aggregator.
     #[api_model(base = "/", table = test_multiple_aggregator_models)]
     pub struct Model {
         #[api_model(primary_key, read_action = find_by_id)]
@@ -52,7 +52,6 @@ mod test_multiple_exist_aggeregators {
         #[api_model(summary, many_to_many = test_multiple_aggregator_model_member_followers, table_name = test_multiple_aggregator_member, foreign_primary_key = member_id, foreign_reference_key = model_id, aggregator = exist)]
         pub followed: bool,
     }
-    // Note: When having the multiple foreign_primary_key "user_id_1", "user_id_2".
 
     #[api_model(base = "/", table = test_multiple_aggregator_model_user_likes)]
     pub struct ModelUserLikes {

--- a/packages/by-macros/tests/test_multiple_exist_aggregators.rs
+++ b/packages/by-macros/tests/test_multiple_exist_aggregators.rs
@@ -21,7 +21,7 @@ mod test_multiple_exist_aggeregators {
         pub email: String,
     }
 
-    #[api_model(base = "/", table = test_multiple_aggregator_member)]
+    #[api_model(base = "/", table = test_multiple_aggregator_members)]
     pub struct Member {
         #[api_model(primary_key)]
         pub id: i64,
@@ -79,7 +79,7 @@ mod test_multiple_exist_aggeregators {
 
         #[api_model(many_to_one = test_multiple_aggregator_models)]
         pub model_id: i64,
-        #[api_model(many_to_one = test_multiple_aggregator_users)]
+        #[api_model(many_to_one = test_multiple_aggregator_members)]
         pub member_id: i64,
     }
 

--- a/packages/by-macros/tests/test_multiple_exist_aggregators.rs
+++ b/packages/by-macros/tests/test_multiple_exist_aggregators.rs
@@ -1,0 +1,209 @@
+#[cfg(feature = "server")]
+pub type Result<T> = std::result::Result<T, by_types::ApiError<String>>;
+
+#[cfg(feature = "server")]
+mod test_multiple_exist_aggeregators {
+    #![allow(unused)]
+    use super::*;
+    use by_axum::aide;
+    use by_macros::api_model;
+    use std::time::SystemTime;
+
+    #[api_model(base = "/", table = test_multiple_aggregator_users)]
+    pub struct User {
+        #[api_model(primary_key)]
+        pub id: i64,
+        #[api_model(auto = [insert])]
+        pub created_at: i64,
+        #[api_model(auto = [insert, update])]
+        pub updated_at: i64,
+        #[api_model(summary, action = signup, unique)]
+        pub email: String,
+    }
+
+    #[api_model(base = "/", table = test_multiple_aggregator_member)]
+    pub struct Member {
+        #[api_model(primary_key)]
+        pub id: i64,
+        #[api_model(auto = [insert])]
+        pub created_at: i64,
+        #[api_model(auto = [insert, update])]
+        pub updated_at: i64,
+        #[api_model(summary, action = create, unique)]
+        pub name: String,
+    }
+
+    // Note: When having the same foreign_primary_key "user_id".
+    #[api_model(base = "/", table = test_multiple_aggregator_models)]
+    pub struct Model {
+        #[api_model(primary_key, read_action = find_by_id)]
+        pub id: i64,
+        #[api_model(auto = insert)]
+        pub created_at: i64,
+        #[api_model(auto = [insert, update])]
+        pub updated_at: i64,
+
+        #[api_model(summary)]
+        pub title: String,
+
+        #[api_model(summary, many_to_many = test_multiple_aggregator_model_user_likes, table_name = test_multiple_aggregator_users, foreign_primary_key = user_id, foreign_reference_key = model_id, aggregator = exist)]
+        pub liked: bool,
+
+        #[api_model(summary, many_to_many = test_multiple_aggregator_model_member_followers, table_name = test_multiple_aggregator_member, foreign_primary_key = member_id, foreign_reference_key = model_id, aggregator = exist)]
+        pub followed: bool,
+    }
+    // Note: When having the multiple foreign_primary_key "user_id_1", "user_id_2".
+
+    #[api_model(base = "/", table = test_multiple_aggregator_model_user_likes)]
+    pub struct ModelUserLikes {
+        #[api_model(summary, primary_key)]
+        pub id: i64,
+        #[api_model(summary, auto = [insert])]
+        pub created_at: i64,
+        #[api_model(summary, auto = [insert, update])]
+        pub updated_at: i64,
+
+        #[api_model(many_to_one = test_multiple_aggregator_models)]
+        pub model_id: i64,
+        #[api_model(many_to_one = test_multiple_aggregator_users)]
+        pub user_id: i64,
+    }
+
+    #[api_model(base = "/", table = test_multiple_aggregator_model_member_followers)]
+    pub struct ModelMemberFollows {
+        #[api_model(summary, primary_key)]
+        pub id: i64,
+        #[api_model(summary, auto = [insert])]
+        pub created_at: i64,
+        #[api_model(summary, auto = [insert, update])]
+        pub updated_at: i64,
+
+        #[api_model(many_to_one = test_multiple_aggregator_models)]
+        pub model_id: i64,
+        #[api_model(many_to_one = test_multiple_aggregator_users)]
+        pub member_id: i64,
+    }
+
+    async fn db_setup(pool: &sqlx::Pool<sqlx::Postgres>) {
+        let query = r#"
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at := EXTRACT(EPOCH FROM now()); -- seconds
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+    "#;
+        sqlx::query(query).execute(pool).await.unwrap();
+
+        let query = r#"
+CREATE OR REPLACE FUNCTION set_created_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.created_at := EXTRACT(EPOCH FROM now()); -- seconds
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+    "#;
+
+        sqlx::query(query).execute(pool).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_user_org() {
+        use sqlx::{postgres::PgPoolOptions, Postgres};
+        let _ = tracing_subscriber::fmt::try_init();
+        let pool: sqlx::Pool<sqlx::Postgres> = sqlx::postgres::PgPoolOptions::new()
+            .max_connections(5)
+            .connect(
+                option_env!("DATABASE_URL")
+                    .unwrap_or("postgres://postgres:postgres@localhost:5432/test"),
+            )
+            .await
+            .unwrap();
+
+        db_setup(&pool).await;
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let user_repo = User::get_repository(pool.clone());
+        let member_repo = Member::get_repository(pool.clone());
+        let model_repo = Model::get_repository(pool.clone());
+        let like_repo = ModelUserLikes::get_repository(pool.clone());
+        let follow_repo = ModelMemberFollows::get_repository(pool.clone());
+
+        user_repo.create_this_table().await;
+        member_repo.create_this_table().await;
+        model_repo.create_this_table().await;
+        like_repo.create_this_table().await;
+        follow_repo.create_this_table().await;
+
+        user_repo.create_related_tables().await;
+        member_repo.create_related_tables().await;
+        model_repo.create_related_tables().await;
+        like_repo.create_related_tables().await;
+        follow_repo.create_related_tables().await;
+
+        let email = format!("{}@example.com", now);
+        let user = user_repo.insert(email.clone()).await;
+        assert!(user.is_ok(), "{:?}", user);
+        let user = user.unwrap();
+
+        let name = format!("member-{}", now);
+        let member = member_repo.insert(name.clone()).await;
+        assert!(member.is_ok(), "{:?}", member);
+        let member = member.unwrap();
+
+        let model = model_repo.insert("TEST 1".to_string()).await;
+        assert!(model.is_ok(), "{:?}", model);
+        let model = model.unwrap();
+
+        let model_user_likes = like_repo.insert(model.id, user.id).await;
+        assert!(model_user_likes.is_ok(), "{:?}", model_user_likes);
+        let r = model_repo
+            .find_one(
+                user.id,
+                member.id,
+                &ModelReadAction::new().find_by_id(model.id),
+            )
+            .await;
+        assert!(r.is_ok(), "{:?}", r);
+        let r = r.unwrap();
+        assert_eq!(r.liked, true);
+        assert_eq!(r.followed, false);
+
+        let r: std::result::Result<Model, sqlx::Error> = Model::query_builder(user.id, member.id)
+            .id_equals(model.id)
+            .query()
+            .map(|r: sqlx::postgres::PgRow| {
+                use sqlx::Row;
+                r.into()
+            })
+            .fetch_one(&pool)
+            .await;
+        assert!(r.is_ok(), "{:?}", r);
+        let r = r.unwrap();
+        assert_eq!(r.liked, true);
+        assert_eq!(r.followed, false);
+
+        let model_user_followers = follow_repo.insert(model.id, member.id).await;
+
+        assert!(model_user_followers.is_ok(), "{:?}", model_user_followers);
+
+        let r: std::result::Result<Model, sqlx::Error> = Model::query_builder(user.id, member.id)
+            .id_equals(model.id)
+            .query()
+            .map(|r: sqlx::postgres::PgRow| {
+                use sqlx::Row;
+                r.into()
+            })
+            .fetch_one(&pool)
+            .await;
+        assert!(r.is_ok(), "{:?}", r);
+        let r = r.unwrap();
+        assert_eq!(r.liked, true);
+        assert_eq!(r.followed, true);
+    }
+}


### PR DESCRIPTION
```
 #[api_model(base = "/", table = models)]
    pub struct Model {
        #[api_model(primary_key, read_action = find_by_id)]
        pub id: i64,
        #[api_model(auto = insert)]
        pub created_at: i64,
        #[api_model(auto = [insert, update])]
        pub updated_at: i64,

        #[api_model(summary)]
        pub title: String,

        #[api_model(summary, many_to_many = model_users_likes, table_name = users, foreign_primary_key = user_id, foreign_reference_key = user_id, aggregator = exist)]
        pub liked: bool,

        #[api_model(summary, many_to_many = model_users_follows, table_name = users, foreign_primary_key = user_id, foreign_reference_key = user_id, aggregator = exist)]
        pub followed: bool,
    }
```
Fixed an issue where the `query_builder` and `find_one` methods were not generated correctly when there was two or more columns with `aggregator=exist`, as in the code above.










<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the handling and structure of aggregate operations for more efficient data processing.

- **Tests**
  - Added automated tests to validate key relationship behaviors, ensuring that interactions such as likes and follows work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->