### PR TITLE
feat(api_model_struct): add integer query and order by functions

### DIFF
--- a/packages/by-macros/src/api_model_struct.rs
+++ b/packages/by-macros/src/api_model_struct.rs
@@ -2632,7 +2632,19 @@ impl ApiModel<'_> {
                         #f
                     })
                 }
-                _ => {}
+                _ => match v.r#type.to_lowercase().as_str() {
+                    "integer" => {
+                        let ty = ty.to_string();
+                        let f = build_integer_query_functions(&v.name, &ty);
+                        let o = build_order_by_functions(&v.name);
+
+                        functions.push(quote! {
+                            #f
+                            #o
+                        });
+                    }
+                    _ => {}
+                },
             }
         }
 

--- a/packages/by-macros/src/query_builder_functions.rs
+++ b/packages/by-macros/src/query_builder_functions.rs
@@ -209,6 +209,10 @@ pub fn build_integer_query_functions(field_name: &str, ty_str: &str) -> proc_mac
     let field_id_str = syn::LitStr::new(field_name, proc_macro2::Span::call_site());
     let bridge = if ty_str == "u32" {
         quote! { as i32 }
+    } else if ty_str != "i32" {
+        quote! {
+           .into()
+        }
     } else {
         quote! {}
     };


### PR DESCRIPTION
+ Added support for integer query and order by functions in `api_model_struct.rs`.
+ Enhanced `build_integer_query_functions` to handle non-i32 integer types.
+ Improved `translate_derive` to handle variant discriminants in `dioxus-translate-macro`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced query functionality by introducing dedicated handling for integer fields, offering tailored query and ordering options.
	- Improved flexibility in integer type conversion, supporting a wider range of numeric representations.
	- Refined translation mapping for a clearer language experience, streamlining the handling of enum variants with explicit discriminants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->