### PR TITLE
feat(api): add orderd by random functionality

### DIFF
--- a/packages/by-macros/src/api_model_struct.rs
+++ b/packages/by-macros/src/api_model_struct.rs
@@ -2648,6 +2648,13 @@ impl ApiModel<'_> {
             }
         }
 
+        functions.push(quote! {
+            pub fn order_by_random(mut self) -> Self {
+                self.order = by_types::Order::Random;
+                self
+            }
+        });
+
         quote! {
             #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
             pub struct #name {

--- a/packages/by-types/src/lib.rs
+++ b/packages/by-types/src/lib.rs
@@ -112,6 +112,7 @@ impl Conditions {
 pub enum Order {
     Asc(Vec<String>),
     Desc(Vec<String>),
+    Random,
     #[default]
     None,
 }
@@ -121,6 +122,7 @@ impl std::fmt::Display for Order {
         let s = match self {
             Order::Asc(field) => format!("ORDER BY {} ASC", field.join(", ")),
             Order::Desc(field) => format!("ORDER BY {} DESC", field.join(", ")),
+            Order::Random => format!("ORDER BY RANDOM()"),
             Order::None => "".to_string(),
         };
 


### PR DESCRIPTION
Added a new method `order_by_random` to the `ApiModel by random. Introduced a new variant `Random` to the `Order` enum.
` struct to support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new ordering option that allows results to be displayed in a random order, enhancing the versatility of data retrieval and presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->