### PR TITLE
feat(by-macros): support non-vector relation field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 /.build/
 /cdk/.projectile
 .build/
+.vscode/*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,7 @@ members = [
   "examples/oauth",
   "examples/auth",
   "examples/basic",
-
-  "packages/*"
+  "packages/*",
 ]
 resolver = "2"
 
@@ -29,23 +28,37 @@ dioxus-translate-macro = { path = "packages/dioxus-translate-macro", version = "
 by-macros = { path = "packages/by-macros", version = "0.6.*" }
 dioxus-logger = { version = "0.5.0" }
 
-aide = { version = "0.14.0", features = ["axum", "axum-query", "axum-extra", "axum-extra-headers", "axum-extra-query", "axum-json", "swagger", "redoc", "scalar", "macros"] }
+aide = { version = "0.14.0", features = [
+  "axum",
+  "axum-query",
+  "axum-extra",
+  "axum-extra-headers",
+  "axum-extra-query",
+  "axum-json",
+  "swagger",
+  "redoc",
+  "scalar",
+  "macros",
+] }
 axum = "0.8.1"
 schemars = { version = "0.8.10", features = ["uuid1"] }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.133"
 reqwest = { version = "0.12.12", features = ["blocking", "json", "multipart"] }
 
-dioxus = { version = "0.6.3", features = ["router", "fullstack"], git = "https://github.com/hackartists/dioxus.git" }
+dioxus = { version = "0.6.3", features = [
+  "router",
+  "fullstack",
+], git = "https://github.com/hackartists/dioxus.git" }
 dioxus-fullstack = { version = "0.6.3", git = "https://github.com/hackartists/dioxus.git" }
 dioxus-cli-config = { version = "0.6.3", git = "https://github.com/hackartists/dioxus.git" }
 dioxus-web = { version = "0.6.3", git = "https://github.com/hackartists/dioxus.git" }
 
 sqlx = { version = "0.8.3", features = [
-    "sqlite",
-    "postgres",
-    "runtime-tokio",
-    "time",
-    "bigdecimal",
+  "sqlite",
+  "postgres",
+  "runtime-tokio",
+  "time",
+  "bigdecimal",
 ] }
 bigdecimal = "0.4.7"

--- a/packages/by-macros/src/sql_model.rs
+++ b/packages/by-macros/src/sql_model.rs
@@ -90,6 +90,12 @@ pub enum AutoOperation {
     Update,
 }
 
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub enum TargetTable {
+    Foreign,
+    Join,
+}
+
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum Aggregator {
     Count,
@@ -118,6 +124,8 @@ pub enum SqlAttribute {
         // Reference key of the current table in the join table
         foreign_reference_key: String,
         reference_key: String,
+
+        target_table: TargetTable,
     },
     ManyToOne {
         table_name: String,
@@ -154,6 +162,7 @@ enum OpenedOffset {
     Auto,
     Version,
     Aggregator,
+    TargetTable,
 }
 
 #[derive(Debug)]
@@ -233,6 +242,9 @@ pub fn parse_field_attr(field: &Field) -> SqlAttributes {
                             "aggregator" => {
                                 opened = OpenedOffset::Aggregator;
                             }
+                            "target_table" => {
+                                opened = OpenedOffset::TargetTable;
+                            }
                             _ => match opened {
                                 OpenedOffset::Aggregator => match id.as_str() {
                                     "count" => {
@@ -306,6 +318,7 @@ pub fn parse_field_attr(field: &Field) -> SqlAttributes {
                                             foreign_primary_key: "".to_string(),
                                             foreign_reference_key: "".to_string(),
                                             reference_key: "id".to_string(),
+                                            target_table: TargetTable::Foreign,
                                         },
                                     );
                                     tracing::trace!("many_to_many: {name}");
@@ -441,6 +454,25 @@ pub fn parse_field_attr(field: &Field) -> SqlAttributes {
                                     {
                                         operations.push(auto);
                                     }
+                                }
+                                OpenedOffset::TargetTable => {
+                                    let target = match id.as_str() {
+                                        "join" => TargetTable::Join,
+                                        "foreign" => TargetTable::Foreign,
+                                        _ => {
+                                            tracing::error!("invalid target table: {id}");
+                                            continue;
+                                        }
+                                    };
+                                    field_attrs.get_mut(&SqlAttributeKey::Relation).map(|attr| {
+                                        if let SqlAttribute::ManyToMany {
+                                            ref mut target_table,
+                                            ..
+                                        } = attr
+                                        {
+                                            *target_table = target;
+                                        }
+                                    });
                                 }
                                 OpenedOffset::None => {}
                             },

--- a/packages/by-macros/src/sql_model.rs
+++ b/packages/by-macros/src/sql_model.rs
@@ -460,8 +460,9 @@ pub fn parse_field_attr(field: &Field) -> SqlAttributes {
                                         "join" => TargetTable::Join,
                                         "foreign" => TargetTable::Foreign,
                                         _ => {
-                                            tracing::error!("invalid target table: {id}");
-                                            continue;
+                                            panic!(
+                                                "target_table mut be either join or foreign: {id}"
+                                            );
                                         }
                                     };
                                     field_attrs.get_mut(&SqlAttributeKey::Relation).map(|attr| {

--- a/packages/by-macros/tests/many_to_many_with_target_table.rs
+++ b/packages/by-macros/tests/many_to_many_with_target_table.rs
@@ -1,0 +1,110 @@
+#[cfg(feature = "server")]
+pub type Result<T> = std::result::Result<T, by_types::ApiError<String>>;
+
+#[cfg(feature = "server")]
+pub mod test_many_to_many_with_target_table {
+    #![allow(unused)]
+    use std::time::SystemTime;
+
+    #[cfg(feature = "server")]
+    use by_axum::aide;
+    use by_macros::api_model;
+    use sqlx::postgres::PgRow;
+    use sqlx::Row;
+    use tokio::time::Instant;
+
+    #[api_model(base = "", table = test_mtm_bills)]
+    pub struct Bill {
+        #[api_model(summary, primary_key)]
+        pub id: i64,
+        #[api_model(summary, auto = insert)]
+        pub created_at: i64,
+
+        #[api_model(summary)]
+        pub title: String,
+
+        #[api_model(many_to_many = test_mtm_votes, type = JSONB, foreign_table_name = test_mtm_users, foreign_primary_key = user_id, foreign_reference_key = model_id, target_table = join)]
+        pub user_votes: Vec<Vote>,
+
+        #[api_model(many_to_many = test_mtm_votes, type = JSONB, foreign_table_name = test_mtm_users, foreign_primary_key = user_id, foreign_reference_key = model_id, target_table = foreign)]
+        pub users: Vec<User>,
+    }
+
+    #[api_model(base = "", table = test_mtm_votes)]
+    pub struct Vote {
+        #[api_model(summary, primary_key)]
+        pub id: i64,
+        #[api_model(summary, auto = [insert])]
+        pub created_at: i64,
+        #[api_model(summary, auto = [insert, update])]
+        pub updated_at: i64,
+        #[api_model(many_to_one = test_mtm_users)]
+        pub user_id: i64,
+        #[api_model(many_to_one = test_mtm_bills)]
+        pub model_id: i64,
+    }
+
+    #[api_model(base = "/v1/users", table = test_mtm_users)]
+    pub struct User {
+        #[api_model(primary_key)]
+        pub id: i64,
+        #[api_model(auto = insert)]
+        pub created_at: i64,
+        #[api_model(auto = [insert, update])]
+        pub updated_at: i64,
+
+        #[api_model(summary, action = signup)]
+        pub email: String,
+    }
+
+    #[tokio::test]
+    async fn test_target_table_parameter() {
+        let _ = tracing_subscriber::fmt::try_init();
+        let pool: sqlx::Pool<sqlx::Postgres> = sqlx::postgres::PgPoolOptions::new()
+            .max_connections(5)
+            .connect(
+                option_env!("DATABASE_URL")
+                    .unwrap_or("postgres://postgres:postgres@localhost:5432/test"),
+            )
+            .await
+            .unwrap();
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let u = User::get_repository(pool.clone());
+        let v = Vote::get_repository(pool.clone());
+        let b = Bill::get_repository(pool.clone());
+
+        b.create_this_table().await;
+        u.create_this_table().await;
+        v.create_this_table().await;
+
+        b.create_related_tables().await;
+        u.create_related_tables().await;
+        v.create_related_tables().await;
+
+        let user_1 = u.insert("test1@gmail.com".to_string()).await.unwrap().id;
+        let user_2 = u.insert("test2@gmail.com".to_string()).await.unwrap().id;
+        let user_3 = u.insert("test3@gmail.com".to_string()).await.unwrap().id;
+
+        let bill = b.insert("BILL".to_string()).await.unwrap();
+
+        let vote_1 = v.insert(user_1, bill.id).await.unwrap();
+        let vote_2 = v.insert(user_2, bill.id).await.unwrap();
+        let vote_3 = v.insert(user_3, bill.id).await.unwrap();
+
+        let r: std::result::Result<Bill, sqlx::Error> = Bill::query_builder()
+            .id_equals(bill.id)
+            .query()
+            .map(Bill::from)
+            .fetch_one(&pool)
+            .await;
+        tracing::debug!("{:?}", r);
+        assert!(r.is_ok());
+        let bill = r.unwrap();
+        assert_eq!(bill.user_votes.len(), 3);
+        assert_eq!(bill.users.len(), 3);
+    }
+}

--- a/packages/by-macros/tests/non_vector_relation_field.rs
+++ b/packages/by-macros/tests/non_vector_relation_field.rs
@@ -1,0 +1,117 @@
+#[cfg(feature = "server")]
+pub type Result<T> = std::result::Result<T, by_types::ApiError<String>>;
+
+#[cfg(feature = "server")]
+pub mod test_non_vector_relation_field {
+    #![allow(unused)]
+    use std::time::SystemTime;
+
+    #[cfg(feature = "server")]
+    use by_axum::aide;
+    use by_macros::api_model;
+    use sqlx::postgres::PgRow;
+    use sqlx::Row;
+
+    #[api_model(base = "/v1/bills", table = test_support_custom_type_bills)]
+    pub struct Bill {
+        #[api_model(summary, primary_key)]
+        pub id: i64,
+        #[api_model(summary, auto = insert)]
+        pub created_at: i64,
+
+        #[api_model(summary)]
+        pub bill_id: String,
+        #[api_model(summary)]
+        pub title: String,
+
+        #[api_model(many_to_many = test_support_custom_type_votes, type = JSONB, foreign_table_name = test_support_custom_type_users, foreign_primary_key = user_id, foreign_reference_key = bill_id, unique)]
+        pub user_vote: SupportVote,
+    }
+
+    #[api_model(base = "/v1/votes", table = test_support_custom_type_votes)]
+    pub struct SupportVote {
+        #[api_model(summary, primary_key)]
+        pub id: i64,
+        #[api_model(summary, auto = [insert])]
+        pub created_at: i64,
+        #[api_model(summary, auto = [insert, update])]
+        pub updated_at: i64,
+        #[api_model(many_to_one = test_support_custom_type_users)]
+        pub user_id: i64,
+        #[api_model(many_to_one = test_support_custom_type_bills)]
+        pub bill_id: i64,
+    }
+
+    #[api_model(base = "/v1/users", table = test_support_custom_type_users)]
+    pub struct SupportUser {
+        #[api_model(primary_key)]
+        pub id: i64,
+        #[api_model(auto = insert)]
+        pub created_at: i64,
+        #[api_model(auto = [insert, update])]
+        pub updated_at: i64,
+
+        #[api_model(summary, action = signup)]
+        pub email: String,
+    }
+
+    #[tokio::test]
+    async fn test_support() {
+        let _ = tracing_subscriber::fmt::try_init();
+        let pool: sqlx::Pool<sqlx::Postgres> = sqlx::postgres::PgPoolOptions::new()
+            .max_connections(5)
+            .connect(
+                option_env!("DATABASE_URL")
+                    .unwrap_or("postgres://postgres:postgres@localhost:5432/support"),
+            )
+            .await
+            .unwrap();
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let u = SupportUser::get_repository(pool.clone());
+        let v = SupportVote::get_repository(pool.clone());
+        let b = Bill::get_repository(pool.clone());
+
+        b.create_this_table().await;
+        u.create_this_table().await;
+        v.create_this_table().await;
+
+        b.create_related_tables().await;
+        u.create_related_tables().await;
+        v.create_related_tables().await;
+
+        let user = u.insert("test@gmail.com".to_string()).await;
+        assert!(user.is_ok(), "{:?}", user);
+        let user = user.unwrap();
+        let bill = b.insert("SOME ID".to_string(), "title".to_string()).await;
+        assert!(bill.is_ok(), "{:?}", bill);
+        let bill = bill.unwrap();
+
+        let r: std::result::Result<Bill, sqlx::Error> = Bill::query_builder()
+            .id_equals(bill.id)
+            .query()
+            .map(Bill::from)
+            .fetch_one(&pool)
+            .await;
+        assert!(r.is_ok(), "{:?}", r);
+
+        assert_eq!(r.unwrap().user_vote.id, 0);
+
+        let vote = v.insert(user.id, bill.id).await;
+        assert!(vote.is_ok(), "{:?}", vote);
+        let vote = vote.unwrap();
+
+        let r: std::result::Result<Bill, sqlx::Error> = Bill::query_builder()
+            .id_equals(bill.id)
+            .query()
+            .map(Bill::from)
+            .fetch_one(&pool)
+            .await;
+        assert!(r.is_ok(), "{:?}", r);
+
+        assert_ne!(r.unwrap().user_vote.id, 0);
+    }
+}


### PR DESCRIPTION
```rust
#[api_model(base = "/v1/bills", table = test_support_custom_type_bills)]
    pub struct Bill {
        #[api_model(summary, primary_key)]
        pub id: i64,
        #[api_model(summary, auto = insert)]
        pub created_at: i64,

        #[api_model(summary)]
        pub bill_id: String,
        #[api_model(summary)]
        pub title: String,

        #[api_model(many_to_many = votes, type = JSONB, foreign_table_name = users, foreign_primary_key = user_id, foreign_reference_key = bill_id, unique)]
        pub user_vote: Vote,
    }
```
Support Non-Vector Fields
NOTICE: `type = JSONB` is Required
    
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated project configuration to ignore unnecessary editor-specific files.
- **Refactor**
  - Enhanced handling of many-to-many relationships with new structured attributes.
- **Tests**
  - Added new test modules to validate many-to-many relationships and their interactions in the database.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->