### PR TITLE
feat: update logging configuration to use RUST_LOG environment variable

### DIFF
--- a/packages/by-axum/src/lib.rs
+++ b/packages/by-axum/src/lib.rs
@@ -17,10 +17,11 @@ pub mod rest_api_adapter;
 pub use by_types::ApiError;
 pub type Result<T, E> = std::result::Result<Json<T>, ApiError<E>>;
 pub use schemars;
+use tracing_subscriber::EnvFilter;
 
 pub fn new() -> BiyardRouter {
     let _ = tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_env_filter(EnvFilter::from(option_env!("RUST_LOG").unwrap_or("info")))
         .with_file(true)
         .with_line_number(true)
         .with_thread_ids(true)


### PR DESCRIPTION
Updated the logging configuration to use the ~RUST_LOG~ environment variable with a default value of "info".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the logging configuration to offer more flexible log level management through environment settings. This adjustment provides enhanced control over logging behavior without altering public functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->