### PR TITLE
feat(dioxus-aws): add tower-http with gzip compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,6 +1339,7 @@ dependencies = [
  "lambda_runtime 0.12.0",
  "tokio",
  "tower 0.4.13",
+ "tower-http 0.6.2",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,6 +1331,7 @@ version = "0.6.18"
 dependencies = [
  "axum 0.7.9",
  "axum-core 0.4.5",
+ "base64 0.22.1",
  "dioxus",
  "dioxus-cli-config",
  "dioxus-fullstack",

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -137,6 +137,7 @@ export class CdkStack extends cdk.Stack {
           cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD_OPTIONS,
           originRequestPolicy:
             cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+          compress: false,
         },
         domainNames: [domain],
         certificate,
@@ -244,50 +245,62 @@ export class CdkStack extends cdk.Stack {
         "/metadata/*": {
           origin: s3Origin,
           cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+          compress: true,
         },
         "/assets/*": {
           origin: s3Origin,
           cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+          compress: true,
         },
         "/*.js": {
           origin: s3Origin,
           cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+          compress: true,
         },
         "/*.css": {
           origin: s3Origin,
           cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+          compress: true,
         },
         "/*.html": {
           origin: s3Origin,
           cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+          compress: true,
         },
         "/*.ico": {
           origin: s3Origin,
           cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+          compress: true,
         },
         "/*.svg": {
           origin: s3Origin,
           cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+          compress: true,
         },
         "/*.avif": {
           origin: s3Origin,
           cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+          compress: true,
         },
         "/*.wasm": {
           origin: s3Origin,
           cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+          compress: true,
         },
         "/icons/*": {
           origin: s3Origin,
           cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+          compress: true,
         },
         "/images/*": {
           origin: s3Origin,
           cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+          compress: true,
         },
         "/public/*": {
           origin: s3Origin,
           cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+          compress: true,
         },
       };
     }

--- a/packages/dioxus-aws/Cargo.toml
+++ b/packages/dioxus-aws/Cargo.toml
@@ -25,11 +25,13 @@ tower-layer = { version = "0.3.3", optional = true }
 tower-service = { version = "0.3.3", optional = true }
 axum-core = { version = "0.4.5", optional = true }
 tower-http = { version = "0.6.2", features = ["compression-gzip"] }
+base64 = { version = "0.22.1", optional = true }
 
 [features]
 default = []
 web = ["dioxus/web", "dioxus-fullstack/web", "dioxus/fullstack"]
 server = ["dioxus/fullstack", "dioxus-fullstack/axum", "dioxus-fullstack/server", "axum", "tokio/full", "dioxus-cli-config", "axum-core", "tower-layer", "tower-service", "tokio"]
 web-only = ["web"]
-lambda = ["server", "tower", "lambda_http", "lambda_runtime", "http"]
+lambda = ["server", "tower", "lambda_http", "lambda_runtime", "http", "base64"]
 tokio = ["dep:tokio"]
+base64 = ["dep:base64"]

--- a/packages/dioxus-aws/Cargo.toml
+++ b/packages/dioxus-aws/Cargo.toml
@@ -24,6 +24,7 @@ http = { version = "1.1.0", optional = true }
 tower-layer = { version = "0.3.3", optional = true }
 tower-service = { version = "0.3.3", optional = true }
 axum-core = { version = "0.4.5", optional = true }
+tower-http = { version = "0.6.2", features = ["compression-gzip"] }
 
 [features]
 default = []

--- a/packages/dioxus-aws/src/lib.rs
+++ b/packages/dioxus-aws/src/lib.rs
@@ -62,10 +62,11 @@ pub fn launch(_app: fn() -> Element) {
 
                 #[cfg(feature = "lambda")]
                 {
-                    use self::lambda::LambdaAdapter;
+                    // use self::lambda::LambdaAdapter;
 
                     tracing::info!("Running in lambda mode");
-                    lambda_runtime::run(LambdaAdapter::from(app)).await.unwrap();
+                    lambda_http::run(app).await.unwrap();
+                    // lambda_runtime::run(LambdaAdapter::from(app)).await.unwrap();
                 }
             });
     };

--- a/packages/dioxus-aws/src/lib.rs
+++ b/packages/dioxus-aws/src/lib.rs
@@ -62,11 +62,11 @@ pub fn launch(_app: fn() -> Element) {
 
                 #[cfg(feature = "lambda")]
                 {
-                    // use self::lambda::LambdaAdapter;
+                    use self::lambda::LambdaAdapter;
 
                     tracing::info!("Running in lambda mode");
-                    lambda_http::run(app).await.unwrap();
-                    // lambda_runtime::run(LambdaAdapter::from(app)).await.unwrap();
+                    // lambda_http::run(app).await.unwrap();
+                    lambda_runtime::run(LambdaAdapter::from(app)).await.unwrap();
                 }
             });
     };

--- a/packages/dioxus-aws/src/lib.rs
+++ b/packages/dioxus-aws/src/lib.rs
@@ -28,6 +28,7 @@ pub fn launch(_app: fn() -> Element) {
     {
         use axum::routing::*;
         use dioxus_fullstack::prelude::*;
+        use tower_http::compression::CompressionLayer;
 
         struct TryIntoResult(Result<ServeConfig, dioxus_fullstack::UnableToLoadIndex>);
 
@@ -42,10 +43,12 @@ pub fn launch(_app: fn() -> Element) {
         tokio::runtime::Runtime::new()
             .unwrap()
             .block_on(async move {
-                let app = Router::new().serve_dioxus_application(
-                    TryIntoResult(ServeConfigBuilder::default().build()),
-                    _app,
-                );
+                let app = Router::new()
+                    .serve_dioxus_application(
+                        TryIntoResult(ServeConfigBuilder::default().build()),
+                        _app,
+                    )
+                    .layer(CompressionLayer::new());
 
                 #[cfg(not(feature = "lambda"))]
                 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a compression layer that enables gzip HTTP response compression, optimizing data transfer efficiency and potentially improving load times.
	- Added a new optional dependency to enhance functionality related to base64 encoding.
	- Updated CloudFront distribution settings to improve content delivery through compression for specific paths.
  
- **Bug Fixes**
	- Improved response header processing and logging for better error tracking based on response status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->