### PR TITLE
*** fix(btracing): correct macro argument type

### DIFF
--- a/packages/btracing/src/lib.rs
+++ b/packages/btracing/src/lib.rs
@@ -94,7 +94,7 @@ macro_rules! info {
 
 #[macro_export]
 macro_rules! i {
-    ($lang:ident, $msg:expr) => {
+    ($lang:expr, $msg:expr) => {
         if tracing::event_enabled!(tracing::Level::INFO) {
             let message = format!("{}", $msg.translate(&$lang));
             tracing::error!("{}", message);


### PR DESCRIPTION
The macro ~i!~ now accepts ~expr~ instead of ~ident~ for the ~lang~ argument, ensuring compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced internal processing to support a broader range of language inputs. This improvement maintains consistent error notifications while offering greater flexibility for future configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->