### PR TITLE
fix reference key for nested one-to-many

### DIFF
--- a/packages/by-macros/src/api_model_struct.rs
+++ b/packages/by-macros/src/api_model_struct.rs
@@ -2623,9 +2623,14 @@ impl ApiModel<'_> {
 
                         tracing::trace!("modified query: \n{}", ret);
                     });
-                } else if let Some(Relation::OneToMany { foreign_key, .. }) = &v.relation {
+                } else if let Some(Relation::OneToMany {
+                    foreign_key,
+                    reference_key,
+                    ..
+                }) = &v.relation
+                {
                     let foreign_key = syn::LitStr::new(
-                        &format!("{} = dummy.id", foreign_key),
+                        &format!("{} = dummy.{}", foreign_key, reference_key),
                         proc_macro2::Span::call_site(),
                     );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced nested relation support by allowing custom reference keys in one-to-many relationships.
  - Added new nested relation and field to test models for improved query flexibility.

- **Tests**
  - Expanded tests to cover scenarios with custom reference keys and nested data loading, ensuring correct linkage and data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->