### PR TITLE
feat(btracing): add default language support for info and error macros

### DIFF
--- a/packages/btracing/src/lib.rs
+++ b/packages/btracing/src/lib.rs
@@ -94,6 +94,19 @@ macro_rules! info {
 
 #[macro_export]
 macro_rules! i {
+    ($msg:expr) => {
+        if tracing::event_enabled!(tracing::Level::INFO) {
+            let message = format!("{}", $msg.translate(&Language::En));
+            tracing::error!("{}", message);
+
+            let p = $crate::ToastMessage {
+                toast_type: $crate::ToastType::Info,
+                message,
+            };
+            *$crate::TOAST.signal().write() = Some(p);
+        }
+    };
+
     ($lang:expr, $msg:expr) => {
         if tracing::event_enabled!(tracing::Level::INFO) {
             let message = format!("{}", $msg.translate(&$lang));
@@ -126,6 +139,19 @@ macro_rules! error {
 
 #[macro_export]
 macro_rules! e {
+    ($err:expr) => {
+        if tracing::event_enabled!(tracing::Level::ERROR) {
+            let message = format!("{}", $err.translate(&Language::En));
+            tracing::error!("{}", message);
+
+            let p = $crate::ToastMessage {
+                toast_type: $crate::ToastType::Error,
+                message,
+            };
+            *$crate::TOAST.signal().write() = Some(p);
+        }
+    };
+
     ($lang:expr, $err:expr) => {
         if tracing::event_enabled!(tracing::Level::ERROR) {
             let message = format!("{}", $err.translate(&$lang));


### PR DESCRIPTION
Added default English language support to the `i!` and `e!` macros in the `btracing` package. These macros now handle messages without requiring an explicit language parameter, improving usability and consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Simplified logging macros now allow single-argument usage for displaying info and error messages, automatically translating messages to English and showing toast notifications.

- **Improvements**
  - Consistent logging behavior across different macro forms for clearer error and info reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->