### PR TITLE
feat(query-builder): add support for `AnyOf` condition in query building

### DIFF
--- a/packages/by-macros/src/api_model_struct.rs
+++ b/packages/by-macros/src/api_model_struct.rs
@@ -2939,6 +2939,10 @@ impl ApiModel<'_> {
                                 tracing::debug!("Binding LessThanEqualsBigint {}", value);
                                 q.bind(value)
                             },
+                            by_types::Conditions::AnyOfBigint(_, value) => {
+                                tracing::debug!("Binding AnyOfBigint {}", value);
+                                q.bind(value)
+                            }
                             by_types::Conditions::BetweenInteger(_, from, to) =>  {
                                 tracing::debug!("Binding BetweenInteger {} and {}", from, to);
                                 q.bind(from).bind(to)
@@ -2967,6 +2971,10 @@ impl ApiModel<'_> {
                                 tracing::debug!("Binding LessThanEqualsInteger {}", value);
                                 q.bind(value)
                             },
+                            by_types::Conditions::AnyOfInteger(_, value) => {
+                                tracing::debug!("Binding AnyOfInteger {}", value);
+                                q.bind(value)
+                            }
                             by_types::Conditions::EqualsText(_, value) => {
                                 tracing::debug!("Binding EqualsText {}", value);
                                 q.bind(value)
@@ -3003,6 +3011,10 @@ impl ApiModel<'_> {
                             by_types::Conditions::NotEndsWithText(_, value) => {
                                 let value = format!("%{}", value);
                                 tracing::debug!("Binding NotEndsWithText {}", value);
+                                q.bind(value)
+                            }
+                            by_types::Conditions::AnyOfText(_, value) => {
+                                tracing::debug!("Binding AnyOfText {}", value);
                                 q.bind(value)
                             }
                             by_types::Conditions::TrueBoolean(_) => {

--- a/packages/by-macros/src/query_builder_functions.rs
+++ b/packages/by-macros/src/query_builder_functions.rs
@@ -77,6 +77,11 @@ pub fn build_string_query_functions(field_name: &str, ty: &str) -> proc_macro2::
         proc_macro2::Span::call_site(),
     );
 
+    let any_of = syn::Ident::new(
+        &format!("{}_any_of", field_name),
+        proc_macro2::Span::call_site(),
+    );
+
     quote! {
         pub fn #eq_fn(mut self, #n: #ty) -> Self {
             self.conditions.push(by_types::Conditions::EqualsText(#field_id_str.to_string(),#n));
@@ -115,6 +120,11 @@ pub fn build_string_query_functions(field_name: &str, ty: &str) -> proc_macro2::
 
         pub fn #not_ends_with_fn(mut self, #n: #ty) -> Self {
             self.conditions.push(by_types::Conditions::NotEndsWithText(#field_id_str.to_string(),#n));
+            self
+        }
+
+        pub fn #any_of(mut self, #n: Vec<#ty>) -> Self {
+            self.conditions.push(by_types::Conditions::AnyOfText(#field_id_str.to_string(),#n));
             self
         }
     }
@@ -165,6 +175,11 @@ pub fn build_bigint_query_functions(field_name: &str, ty_str: &str) -> proc_macr
         proc_macro2::Span::call_site(),
     );
 
+    let any_of = syn::Ident::new(
+        &format!("{}_any_of", field_name),
+        proc_macro2::Span::call_site(),
+    );
+
     quote! {
         pub fn #eq_fn(mut self, #n: #ty) -> Self {
             self.conditions.push(by_types::Conditions::EqualsBigint(#field_id_str.to_string(),#n #bridge));
@@ -198,6 +213,11 @@ pub fn build_bigint_query_functions(field_name: &str, ty_str: &str) -> proc_macr
 
         pub fn #between_fn(mut self, from: #ty, to: #ty) -> Self {
             self.conditions.push(by_types::Conditions::BetweenBigint(#field_id_str.to_string(),from #bridge,to #bridge));
+            self
+        }
+
+        pub fn #any_of(mut self, #n: Vec<#ty>) -> Self {
+            self.conditions.push(by_types::Conditions::AnyOfBigint(#field_id_str.to_string(),#n #bridge));
             self
         }
     }
@@ -252,6 +272,11 @@ pub fn build_integer_query_functions(field_name: &str, ty_str: &str) -> proc_mac
         proc_macro2::Span::call_site(),
     );
 
+    let any_of = syn::Ident::new(
+        &format!("{}_any_of", field_name),
+        proc_macro2::Span::call_site(),
+    );
+
     quote! {
         pub fn #eq_fn(mut self, #n: #ty) -> Self {
             self.conditions.push(by_types::Conditions::EqualsInteger(#field_id_str.to_string(),#n #bridge));
@@ -285,6 +310,11 @@ pub fn build_integer_query_functions(field_name: &str, ty_str: &str) -> proc_mac
 
         pub fn #between_fn(mut self, from: #ty, to: #ty) -> Self {
             self.conditions.push(by_types::Conditions::BetweenInteger(#field_id_str.to_string(),from #bridge,to #bridge));
+            self
+        }
+
+        pub fn #any_of(mut self, #n: Vec<#ty>) -> Self {
+            self.conditions.push(by_types::Conditions::AnyOfInteger(#field_id_str.to_string(),#n #bridge));
             self
         }
     }

--- a/packages/by-macros/tests/query_builder.rs
+++ b/packages/by-macros/tests/query_builder.rs
@@ -243,6 +243,19 @@ pub mod update_into_tests {
 
         assert_eq!(docs.len(), 20);
 
+        let docs: Vec<QueryModel> = QueryModel::query_builder()
+            .name_any_of(vec![
+                format!("{} 0-true", name),
+                format!("{} 0-false", name),
+            ])
+            .query()
+            .map(|r: PgRow| r.into())
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+
+        assert_eq!(docs.len(), 2);
+
         let doc: QueryModel = q
             .query()
             .map(|r: PgRow| r.into())
@@ -405,6 +418,17 @@ pub mod update_into_tests {
             .unwrap();
 
         assert_eq!(docs.len(), 18);
+
+        let docs: Vec<QueryModel> = QueryModel::query_builder()
+            .name_contains(name.clone())
+            .num_any_of(vec![1, 2])
+            .query()
+            .map(|r: PgRow| r.into())
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+
+        assert_eq!(docs.len(), 2);
 
         for doc in docs {
             assert!(doc.num != 5);

--- a/packages/by-types/src/lib.rs
+++ b/packages/by-types/src/lib.rs
@@ -36,6 +36,7 @@ pub enum Conditions {
     LessThanBigint(String, i64),
     GreaterThanEqualsBigint(String, i64),
     LessThanEqualsBigint(String, i64),
+    AnyOfBigint(String, Vec<i32>),
 
     BetweenInteger(String, i32, i32),
     EqualsInteger(String, i32),
@@ -44,6 +45,7 @@ pub enum Conditions {
     LessThanInteger(String, i32),
     GreaterThanEqualsInteger(String, i32),
     LessThanEqualsInteger(String, i32),
+    AnyOfInteger(String, Vec<i32>),
 
     EqualsText(String, String),
     NotEqualsText(String, String),
@@ -53,6 +55,7 @@ pub enum Conditions {
     NotStartsWithText(String, String),
     EndsWithText(String, String),
     NotEndsWithText(String, String),
+    AnyOfText(String, Vec<String>),
 
     TrueBoolean(String),
     FalseBoolean(String),
@@ -73,6 +76,7 @@ impl Conditions {
             Conditions::LessThanBigint(field, _) => format!("{} < ${}", field, i),
             Conditions::GreaterThanEqualsBigint(field, _) => format!("{} >= ${}", field, i),
             Conditions::LessThanEqualsBigint(field, _) => format!("{} <= ${}", field, i),
+            Conditions::AnyOfBigint(field, _) => format!("{} = ANY(${})", field, i),
 
             Conditions::BetweenInteger(field, _, _) => {
                 let q = format!("{} BETWEEN ${} AND ${}", field, i, i + 1);
@@ -84,6 +88,7 @@ impl Conditions {
             Conditions::LessThanInteger(field, _) => format!("{} < ${}", field, i),
             Conditions::GreaterThanEqualsInteger(field, _) => format!("{} >= ${}", field, i),
             Conditions::LessThanEqualsInteger(field, _) => format!("{} <= ${}", field, i),
+            Conditions::AnyOfInteger(field, _) => format!("{} = ANY(${})", field, i),
 
             Conditions::EqualsText(field, _) => format!("{} = ${}", field, i),
             Conditions::NotEqualsText(field, _) => format!("{} != ${}", field, i),
@@ -93,6 +98,7 @@ impl Conditions {
             Conditions::NotStartsWithText(field, _) => format!("{} NOT ILIKE ${}", field, i),
             Conditions::EndsWithText(field, _) => format!("{} ILIKE ${}", field, i),
             Conditions::NotEndsWithText(field, _) => format!("{} NOT ILIKE ${}", field, i),
+            Conditions::AnyOfText(field, _) => format!("{} = ANY(${})", field, i),
 
             Conditions::TrueBoolean(field) => {
                 let q = format!("{} = true", field);


### PR DESCRIPTION
This commit introduces the `AnyOf` condition for bigint, integer, and text fields in the query builder. The new condition allows filtering records where a field matches any value from a provided list.

- Added `AnyOfBigint`, `AnyOfInteger`, and `AnyOfText` variants to the `Conditions` enum.
- Updated query generation logic to handle `AnyOf` conditions using the `ANY` SQL operator.
- Extended query builder functions to include methods for `AnyOf` conditions.
- Added tests to validate the functionality of `AnyOf` conditions for bigint, integer, and text fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for multi-value matching ("any of") conditions in query filters for string, integer, and bigint fields.
  - Introduced new query builder methods to filter results based on whether a field matches any value in a provided list.

- **Tests**
  - Expanded test coverage to validate the new "any of" query filter functionality for string and numeric fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->