### PR TITLE
fix(macros): handle enum variant discriminants correctly in derive_api_model

### DIFF
--- a/packages/by-macros/src/lib.rs
+++ b/packages/by-macros/src/lib.rs
@@ -80,7 +80,7 @@ pub fn derive_api_model(input: TokenStream) -> TokenStream {
             None => quote! { compile_error!("Enum variants must have explicit discriminants"); },
         };
         tracing::trace!("discriminant: {}", discriminant.to_string());
-        quote! { #discriminant => Ok(#name::#ident), }
+        quote! { val if val == #discriminant => Ok(#name::#ident), }
     });
 
     let expanded = quote! {


### PR DESCRIPTION
- fixed compilation error for the below enum

``` rust
#[derive(ApiModel)]
pub enum Enum {
    Var1 = 1,
    Var2 = 1 << 2,
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated internal matching logic for enum conversions to improve code consistency. No changes to user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->