### PR TITLE
feat(by-macros): add GraphQL support with async-graphql integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +110,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "ascii_utils"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
+
+[[package]]
 name = "ashpd"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +173,80 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "async-graphql"
+version = "7.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "036618f842229ba0b89652ffe425f96c7c16a49f7e3cb23b56fca7f61fd74980"
+dependencies = [
+ "async-graphql-derive",
+ "async-graphql-parser",
+ "async-graphql-value",
+ "async-stream",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "fast_chemail",
+ "fnv",
+ "futures-timer",
+ "futures-util",
+ "handlebars",
+ "http 1.2.0",
+ "indexmap 2.7.1",
+ "mime",
+ "multer",
+ "num-traits",
+ "pin-project-lite",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "static_assertions_next",
+ "tempfile",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "async-graphql-derive"
+version = "7.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd45deb3dbe5da5cdb8d6a670a7736d735ba65b455328440f236dfb113727a3d"
+dependencies = [
+ "Inflector",
+ "async-graphql-parser",
+ "darling",
+ "proc-macro-crate 3.3.0",
+ "proc-macro2",
+ "quote",
+ "strum",
+ "syn 2.0.100",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "async-graphql-parser"
+version = "7.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b7607e59424a35dadbc085b0d513aa54ec28160ee640cf79ec3b634eba66d3"
+dependencies = [
+ "async-graphql-value",
+ "pest",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-graphql-value"
+version = "7.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ecdaff7c9cffa3614a9f9999bf9ee4c3078fe3ce4d6a6e161736b56febf2de"
+dependencies = [
+ "bytes",
+ "indexmap 2.7.1",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1094,6 +1184,7 @@ dependencies = [
 name = "by-macros"
 version = "0.6.9"
 dependencies = [
+ "async-graphql-derive",
  "bigdecimal",
  "by-axum",
  "by-types",
@@ -1122,6 +1213,7 @@ name = "by-types"
 version = "0.3.9"
 dependencies = [
  "aide",
+ "async-graphql",
  "axum 0.8.4",
  "cookie",
  "gloo-net",
@@ -2604,6 +2696,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast_chemail"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "495a39d30d624c2caabe6312bfead73e7717692b44e0b32df168c275a2e8e9e4"
+dependencies = [
+ "ascii_utils",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2816,6 +2917,12 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -3078,7 +3185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
 dependencies = [
  "heck 0.4.1",
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 2.0.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -3300,6 +3407,20 @@ checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "cfg-if",
  "crunchy",
+]
+
+[[package]]
+name = "handlebars"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08485b96a0e6393e9e4d1b8d48cf74ad6c063cd905eb33f42c1ce3f0377539b"
+dependencies = [
+ "log",
+ "pest",
+ "pest_derive",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4681,7 +4802,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -5078,6 +5199,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pest"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.12",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "phf"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5336,12 +5502,20 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
- "toml_datetime",
  "toml_edit 0.20.2",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit 0.22.26",
 ]
 
 [[package]]
@@ -5774,7 +5948,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6709,6 +6883,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "static_assertions_next"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7beae5182595e9a8b683fa98c4317f956c9a2dec3b9716990d20023cc60c766"
+
+[[package]]
 name = "static_str_ops"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6759,6 +6939,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "subtle"
@@ -7175,9 +7377,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
  "serde",
 ]
@@ -7190,7 +7392,7 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.7.1",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -7203,7 +7405,18 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+dependencies = [
+ "indexmap 2.7.1",
+ "toml_datetime",
+ "winnow 0.7.10",
 ]
 
 [[package]]
@@ -7464,6 +7677,12 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uds_windows"
@@ -7931,7 +8150,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8353,6 +8572,15 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]

--- a/packages/by-macros/Cargo.toml
+++ b/packages/by-macros/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/biyard/rust-sdk/tree/main/packages/by-macros"
 proc-macro = true
 
 [dependencies]
+async-graphql-derive = "7.0.17"
 bigdecimal = "0.4.7"
 convert_case = "0.7.1"
 indexmap = "2.7.1"

--- a/packages/by-macros/src/api_model_struct.rs
+++ b/packages/by-macros/src/api_model_struct.rs
@@ -21,6 +21,7 @@ use tracing::instrument;
 #[cfg(feature = "server")]
 use crate::sql_model::*;
 
+#[derive(PartialEq)]
 pub enum Database {
     Postgres,
 }
@@ -39,6 +40,7 @@ pub struct ApiModel<'a> {
     pub database: Option<Database>,
 
     pub result_type: proc_macro2::TokenStream,
+    pub graphql: bool,
 
     pub name: String,
     pub name_id: &'a syn::Ident,
@@ -3495,6 +3497,7 @@ impl<'a> ApiModel<'a> {
         let mut parent_ids = Vec::new();
         let mut iter_type = "by_types::QueryResponse".to_string();
         let mut custom_query_type = None;
+        let mut graphql = true;
         let mut result_type: proc_macro2::TokenStream = "crate::Result".parse().unwrap();
         let mut read_action_names = IndexMap::<String, ActionField>::new();
         let actions = attr
@@ -3524,6 +3527,9 @@ impl<'a> ApiModel<'a> {
                             })
                             .collect::<Vec<&str>>()
                             .join("/");
+                    }
+                    "graphql" => {
+                        graphql = value.to_string() == "true";
                     }
                     "iter_type" => iter_type = value.to_string(),
                     "custom_query_type" => custom_query_type = Some(value.to_string()),
@@ -3740,6 +3746,7 @@ impl<'a> ApiModel<'a> {
             database,
             #[cfg(feature = "server")]
             primary_key,
+            graphql,
 
             result_type,
 

--- a/packages/by-macros/src/graphql.rs
+++ b/packages/by-macros/src/graphql.rs
@@ -1,0 +1,75 @@
+use indexmap::IndexMap;
+use quote::quote;
+
+pub fn generate_graphql(m: &crate::api_model_struct::ApiModel) -> proc_macro2::TokenStream {
+    if !m.graphql || m.database.is_none() {
+        return quote! {};
+    }
+
+    let struct_name = m.struct_name();
+
+    let lowercase_struct_name = struct_name.to_string().to_lowercase();
+    let plural_struct_name = format!("{}s", lowercase_struct_name);
+    let endpoint_name = format!("{}Endpoints", struct_name.to_string());
+    let lowercase_struct_name =
+        syn::Ident::new(&lowercase_struct_name, proc_macro2::Span::call_site());
+    let plural_struct_name = syn::Ident::new(&plural_struct_name, proc_macro2::Span::call_site());
+    let endpoint_name = syn::Ident::new(&endpoint_name, proc_macro2::Span::call_site());
+
+    let mut aggregate_args: IndexMap<String, proc_macro2::TokenStream> = IndexMap::new();
+    let mut arg_names = vec![];
+
+    for (_, field) in m.fields.iter() {
+        for (name, q) in field.aggregate_arg() {
+            aggregate_args.insert(name.clone(), q);
+
+            let arg_name = syn::Ident::new(&name, proc_macro2::Span::call_site());
+            arg_names.push(arg_name);
+        }
+    }
+
+    let aggregate_args: Vec<proc_macro2::TokenStream> = aggregate_args.into_values().collect();
+
+    let output = quote! {
+        pub struct #endpoint_name;
+
+        #[async_graphql::Object]
+        impl #endpoint_name {
+            async fn #lowercase_struct_name<'a>(&self, ctx: &async_graphql::Context<'a>, #(#aggregate_args),*) -> async_graphql::Result<#struct_name> {
+                let pool = ctx
+                    .data::<sqlx::Pool<sqlx::Postgres>>()
+                    .expect("Database pool not found");
+
+                let doc = #struct_name::query_builder(#(#arg_names),*)
+                    // .id_equals(id)
+                    .query()
+                    .map(#struct_name::from)
+                    .fetch_one(pool)
+                    .await?;
+
+                Ok(doc)
+
+            }
+
+            async fn #plural_struct_name<'a>(&self, ctx: &async_graphql::Context<'a>, size: i32, page: i32, #(#aggregate_args),*) -> async_graphql::Result<Vec<#struct_name>> {
+                let pool = ctx
+                    .data::<sqlx::Pool<sqlx::Postgres>>()
+                    .expect("Database pool not found");
+
+                let docs = #struct_name::query_builder(#(#arg_names),*)
+                    .limit(size)
+                    .page(page)
+                    .query()
+                    .map(#struct_name::from)
+                    .fetch_all(pool)
+                    .await?;
+
+                Ok(docs)
+            }
+
+        }
+
+    };
+
+    output.into()
+}

--- a/packages/by-macros/src/lib.rs
+++ b/packages/by-macros/src/lib.rs
@@ -4,10 +4,12 @@ mod action;
 mod api_model;
 mod api_model_struct;
 mod enum_prop;
+pub(crate) mod graphql;
 pub(crate) mod parse_queryable_fields;
 #[cfg(feature = "server")]
 mod query_builder_functions;
 mod query_display;
+mod query_root;
 #[cfg(feature = "server")]
 mod sql_model;
 
@@ -17,6 +19,11 @@ use proc_macro::TokenStream;
 use query_display::query_display_impl;
 use quote::{quote, ToTokens};
 use syn::{parse_macro_input, Data, DataEnum, DeriveInput, Fields};
+
+#[proc_macro]
+pub fn query_root(input: TokenStream) -> TokenStream {
+    query_root::query_root_impl(input)
+}
 
 #[proc_macro_derive(QueryDisplay)]
 pub fn query_display_derive(input: TokenStream) -> TokenStream {

--- a/packages/by-macros/src/query_root.rs
+++ b/packages/by-macros/src/query_root.rs
@@ -1,0 +1,57 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, punctuated::Punctuated, ExprPath, Ident, Token};
+
+pub fn query_root_impl(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as QueryRootInput);
+
+    let methods = input.fields.iter().map(|field| {
+        let field_name = &field.name;
+        let type_name = &field.ty;
+        quote! {
+            async fn #field_name(&self) -> &#type_name {
+                &#type_name
+            }
+        }
+    });
+
+    let expanded = quote! {
+        #[::async_graphql::Object]
+        impl QueryRoot {
+            #(#methods)*
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
+// Structs to parse macro input
+use syn::parse::{Parse, ParseStream, Result};
+
+struct QueryField {
+    name: Ident,
+    _arrow: Token![=>],
+    ty: ExprPath,
+}
+
+impl Parse for QueryField {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(QueryField {
+            name: input.parse()?,
+            _arrow: input.parse()?,
+            ty: input.parse()?,
+        })
+    }
+}
+
+struct QueryRootInput {
+    fields: Punctuated<QueryField, Token![,]>,
+}
+
+impl Parse for QueryRootInput {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(QueryRootInput {
+            fields: Punctuated::parse_terminated(input)?,
+        })
+    }
+}

--- a/packages/by-types/Cargo.toml
+++ b/packages/by-types/Cargo.toml
@@ -25,6 +25,7 @@ tracing = "0.1.41"
 serde_json.workspace = true
 cookie = { version = "0.18.1", optional = true }
 gloo-net = { workspace = true }
+async-graphql = "7.0.17"
 
 [features]
 server = ["aide", "axum", "schemars", "sqlx", "cookie"]


### PR DESCRIPTION
Introduce GraphQL support in the `by-macros` package by integrating `async-graphql`. Added a new `graphql` module to generate GraphQL endpoints for models. Updated `ApiModel` to include a `graphql` flag and generate appropriate GraphQL objects and endpoints. Introduced a `query_root` procedural macro for defining GraphQL query roots. Updated dependencies to include `async-graphql`.

BREAKING CHANGE: Models now require a `graphql` flag to enable GraphQL endpoint generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced GraphQL endpoint code generation for API models with GraphQL enabled.
  - Added a procedural macro for generating async GraphQL query root objects.
- **Enhancements**
  - Models can now include a `graphql` attribute to enable or disable GraphQL support.
  - Added support for GraphQL-related code and dependencies in relevant packages.
- **Bug Fixes**
  - No bug fixes included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->