### PR TITLE
Add dioxus-gtag package for Google Analytics 4 integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,16 +37,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "aide"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2477554ebf38aea815a9c4729100cfc32f766876c45b9c9c38ef221b9d1a703"
+dependencies = [
+ "aide-macros",
+ "axum",
+ "axum-extra",
+ "bytes",
+ "cfg-if",
+ "http",
+ "indexmap",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "thiserror 2.0.12",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "aide-macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8e0d4af7cc08353807aaf80722125a229bf2d67be7fe0b89163c648db3d223"
+dependencies = [
+ "darling 0.20.10",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "ar_archive_writer"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
+dependencies = [
+ "object 0.37.3",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "async-trait"
@@ -56,7 +126,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -103,6 +173,96 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "axum-macros",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-extra"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "headers",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "serde_core",
+ "serde_html_form",
+ "serde_path_to_error",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,7 +272,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.36.7",
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
@@ -149,6 +309,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "binread"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16598dfc8e6578e9b597d9910ba2e73618385dc9f4b1d43dd92c349d6be6418f"
+dependencies = [
+ "binread_derive",
+ "lazy_static",
+ "rustversion",
+]
+
+[[package]]
+name = "binread_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9672209df1714ee804b1f4d4f68c8eb2a90b1f7a07acf472f88ce198ef1fed"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,27 +356,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
+name = "by-axum"
+version = "0.2.14"
+source = "git+https://github.com/biyard/rust-sdk.git?rev=fdb8ab49bd08fd9ff263fe11381038c6d45d4ef9#fdb8ab49bd08fd9ff263fe11381038c6d45d4ef9"
+dependencies = [
+ "aide",
+ "axum",
+ "by-types",
+ "http",
+ "hyper",
+ "jsonwebtoken",
+ "reqwest 0.12.28",
+ "rest-api",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "slog",
+ "slog-async",
+ "slog-term",
+ "static_str_ops",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "tower-sessions",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "by-macros"
 version = "0.6.20"
 dependencies = [
  "Inflector",
  "bigdecimal",
+ "by-axum",
+ "by-types",
  "convert_case 0.7.1",
  "indexmap",
  "lazy_static",
  "proc-macro2",
  "quote",
  "regex",
- "reqwest",
- "schemars",
+ "reqwest 0.13.4",
+ "rest-api",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sqlx",
- "syn",
+ "syn 2.0.117",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "validator",
+]
+
+[[package]]
+name = "by-types"
+version = "0.3.9"
+source = "git+https://github.com/biyard/rust-sdk.git?rev=fdb8ab49bd08fd9ff263fe11381038c6d45d4ef9#fdb8ab49bd08fd9ff263fe11381038c6d45d4ef9"
+dependencies = [
+ "aide",
+ "axum",
+ "cookie",
+ "gloo-net",
+ "reqwest 0.12.28",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tracing",
  "validator",
 ]
 
@@ -208,6 +441,41 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "candid"
+version = "0.10.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8f781afa4a1303e3eab4ada0720a874942bcfa936ce01b816ac6378945c43a9"
+dependencies = [
+ "anyhow",
+ "binread",
+ "byteorder",
+ "candid_derive",
+ "hex",
+ "ic_principal",
+ "leb128",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "pretty",
+ "serde",
+ "serde_bytes",
+ "stacker",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "candid_derive"
+version = "0.10.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad6ae8e7944dd0035651bc0e7b3a3e4cb16f5fc43f8ae4fd76b36ff2cd52759f"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "cc"
@@ -234,6 +502,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,6 +532,23 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -307,6 +605,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +664,24 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-queue"
@@ -412,7 +739,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -425,7 +752,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -436,7 +763,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -447,7 +774,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -465,6 +792,16 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -544,7 +881,7 @@ dependencies = [
  "dioxus-rsx",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -566,7 +903,7 @@ dependencies = [
  "serde",
  "serde_json",
  "subsecond",
- "thiserror",
+ "thiserror 2.0.12",
  "tracing",
  "tungstenite",
 ]
@@ -669,7 +1006,7 @@ dependencies = [
  "convert_case 0.8.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -720,7 +1057,7 @@ dependencies = [
  "quote",
  "sha2",
  "slab",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -733,7 +1070,7 @@ dependencies = [
  "proc-macro2-diagnostics",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -773,7 +1110,7 @@ dependencies = [
  "convert_case 0.8.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -816,7 +1153,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -873,7 +1210,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -881,6 +1218,15 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "errno"
@@ -936,6 +1282,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,6 +1315,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,6 +1343,21 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-channel"
@@ -1025,7 +1411,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1046,6 +1432,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1075,6 +1462,18 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gensym"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913dce4c5f06c2ea40fc178c06f777ac89fc6b1383e90c254fafb1abe4ba3c82"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "uuid",
 ]
 
 [[package]]
@@ -1109,6 +1508,40 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "gloo-net"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06f627b1a58ca3d42b45d6104bf1e1a03799df472df00988b6ba21accc10580"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-sink",
+ "gloo-utils",
+ "http",
+ "js-sys",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
 
 [[package]]
 name = "h2"
@@ -1150,10 +1583,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1229,6 +1692,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,6 +1711,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1263,6 +1733,22 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -1289,6 +1775,43 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "ic_principal"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aea751965eaf92990be8c79c64b4f3174ff22dd3604e6696a06a494afbaba2a"
+dependencies = [
+ "crc32fast",
+ "data-encoding",
+ "serde",
+ "sha2",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1406,7 +1929,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1444,6 +1967,7 @@ checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -1451,6 +1975,17 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "itoa"
@@ -1470,7 +2005,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.12",
  "walkdir",
  "windows-link",
 ]
@@ -1485,7 +2020,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1504,7 +2039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1525,6 +2060,21 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -1565,6 +2115,12 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
+
+[[package]]
+name = "leb128"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
 
 [[package]]
 name = "libc"
@@ -1618,6 +2174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
+ "serde",
 ]
 
 [[package]]
@@ -1646,6 +2203,12 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -1688,12 +2251,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1705,6 +2279,23 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe 0.1.6",
+ "openssl-sys",
+ "schannel",
+ "security-framework 2.11.1",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1725,6 +2316,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -1743,6 +2335,12 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1784,16 +2382,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
+name = "openssl"
+version = "0.10.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "overload"
@@ -1831,6 +2481,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,7 +2528,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1905,12 +2571,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "pretty"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d22152487193190344590e4f30e219cf3fe140d9e7a3fdb683d82aa2c5f4156"
+dependencies = [
+ "arrayvec",
+ "typed-arena",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1932,7 +2615,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1952,8 +2635,18 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "version_check",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -1970,7 +2663,7 @@ dependencies = [
  "rustc-hash 2.1.2",
  "rustls",
  "socket2 0.6.4",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "web-time",
@@ -1992,7 +2685,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2106,7 +2799,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2155,6 +2848,49 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "mime_guess",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -2188,6 +2924,23 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "rest-api"
+version = "0.1.10"
+source = "git+https://github.com/biyard/rust-sdk.git?rev=fdb8ab49bd08fd9ff263fe11381038c6d45d4ef9#fdb8ab49bd08fd9ff263fe11381038c6d45d4ef9"
+dependencies = [
+ "base64",
+ "candid",
+ "chrono",
+ "gloo-net",
+ "reqwest 0.12.28",
+ "ring",
+ "serde",
+ "simple_asn1",
+ "tracing",
  "web-sys",
 ]
 
@@ -2285,10 +3038,10 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -2315,7 +3068,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -2371,16 +3124,42 @@ dependencies = [
 
 [[package]]
 name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "indexmap",
+ "schemars_derive 0.8.22",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
- "schemars_derive",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
  "uuid",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2392,7 +3171,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2400,6 +3179,19 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
 
 [[package]]
 name = "security-framework"
@@ -2461,6 +3253,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2477,7 +3279,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2488,7 +3290,20 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_html_form"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2f2d7ff8a2140333718bb329f5c40fc5f0865b84c426183ce14c97d2ab8154f"
+dependencies = [
+ "form_urlencoded",
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde_core",
 ]
 
 [[package]]
@@ -2501,6 +3316,30 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b417bedc008acbdf6d6b4bc482d29859924114bbe2650b7921fb68a261d0aa6"
+dependencies = [
+ "axum",
+ "futures",
+ "percent-encoding",
+ "serde",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2572,6 +3411,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2586,6 +3431,18 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.12",
+ "time",
+]
 
 [[package]]
 name = "slab"
@@ -2610,7 +3467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb251b407f50028476a600541542b605bb864d35d9ee1de4f6cab45d88475e6d"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2620,6 +3477,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "debdd4b83524961983cea3c55383b3910fd2f24fd13a188f5b091d2d504a61ae"
 dependencies = [
  "rustc-hash 1.1.0",
+]
+
+[[package]]
+name = "slog"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3b8565691b22d2bdfc066426ed48f837fc0c5f2c8cad8d9718f7f99d6995c1"
+dependencies = [
+ "anyhow",
+ "erased-serde",
+ "rustversion",
+ "serde_core",
+]
+
+[[package]]
+name = "slog-async"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c8038f898a2c79507940990f05386455b3a317d8f18d4caea7cbc3d5096b84"
+dependencies = [
+ "crossbeam-channel",
+ "slog",
+ "take_mut",
+ "thread_local",
+]
+
+[[package]]
+name = "slog-term"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cb1fc680b38eed6fad4c02b3871c09d2c81db8c96aa4e9c0a34904c830f09b5"
+dependencies = [
+ "chrono",
+ "is-terminal",
+ "slog",
+ "term",
+ "thread_local",
+ "time",
 ]
 
 [[package]]
@@ -2720,7 +3615,8 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.12",
+ "time",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2737,7 +3633,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2760,7 +3656,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn",
+ "syn 2.0.117",
  "tempfile",
  "tokio",
  "url",
@@ -2804,7 +3700,8 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.12",
+ "time",
  "tracing",
  "whoami",
 ]
@@ -2843,7 +3740,8 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.12",
+ "time",
  "tracing",
  "whoami",
 ]
@@ -2867,6 +3765,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
+ "time",
  "tracing",
  "url",
 ]
@@ -2876,6 +3775,29 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "static_str_ops"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eef2389280bc4d03836302f127e5e784c63cd183e24fe35cf73dc7f3b13a47d4"
+dependencies = [
+ "gensym",
+ "lazy_static",
+]
 
 [[package]]
 name = "stringprep"
@@ -2907,7 +3829,7 @@ dependencies = [
  "memmap2",
  "serde",
  "subsecond-types",
- "thiserror",
+ "thiserror 2.0.12",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -2927,6 +3849,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2956,7 +3889,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2981,6 +3914,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
 name = "tempfile"
 version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2995,12 +3934,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3011,7 +3979,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3022,6 +3990,37 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -3075,7 +4074,17 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -3125,6 +4134,23 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-cookies"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "151b5a3e3c45df17466454bb74e9ecedecc955269bdedbf4d150dfa393b55a36"
+dependencies = [
+ "axum-core",
+ "cookie",
+ "futures-util",
+ "http",
+ "parking_lot",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -3133,15 +4159,20 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
  "url",
 ]
 
@@ -3156,6 +4187,57 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tower-sessions"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a05911f23e8fae446005fe9b7b97e66d95b6db589dc1c4d59f6a2d4d4927d3"
+dependencies = [
+ "async-trait",
+ "http",
+ "time",
+ "tokio",
+ "tower-cookies",
+ "tower-layer",
+ "tower-service",
+ "tower-sessions-core",
+ "tower-sessions-memory-store",
+ "tracing",
+]
+
+[[package]]
+name = "tower-sessions-core"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8cce604865576b7751b7a6bc3058f754569a60d689328bb74c52b1d87e355b"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "base64",
+ "futures",
+ "http",
+ "parking_lot",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "time",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "tower-sessions-memory-store"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb05909f2e1420135a831dd5df9f5596d69196d0a64c3499ca474c4bd3d33242"
+dependencies = [
+ "async-trait",
+ "time",
+ "tokio",
+ "tower-sessions-core",
+]
 
 [[package]]
 name = "tracing"
@@ -3177,7 +4259,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3238,15 +4320,27 @@ dependencies = [
  "log",
  "rand 0.9.4",
  "sha1",
- "thiserror",
+ "thiserror 2.0.12",
  "utf-8",
 ]
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"
@@ -3280,6 +4374,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -3327,6 +4427,9 @@ name = "uuid"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
+dependencies = [
+ "getrandom 0.3.1",
+]
 
 [[package]]
 name = "validator"
@@ -3355,7 +4458,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3414,7 +4517,7 @@ checksum = "59195a1db0e95b920366d949ba5e0d3fc0e70b67c09be15ce5abb790106b0571"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3480,7 +4583,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3575,6 +4678,41 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "windows-link"
@@ -3809,7 +4947,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3830,7 +4968,7 @@ checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3850,7 +4988,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3879,5 +5017,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,7 +944,17 @@ version = "0.1.0"
 dependencies = [
  "by-macros",
  "dioxus",
+ "dioxus-gtag-macro",
  "serde_json",
+]
+
+[[package]]
+name = "dioxus-gtag-macro"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,6 +118,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27c3610c36aee21ce8ac510e6224498de4228ad772a171ed65643a24693a5a8"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,7 +178,7 @@ version = "0.6.20"
 dependencies = [
  "Inflector",
  "bigdecimal",
- "convert_case",
+ "convert_case 0.7.1",
  "indexmap",
  "lazy_static",
  "proc-macro2",
@@ -245,10 +268,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -334,8 +387,18 @@ version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.10",
+ "darling_macro 0.20.10",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -353,15 +416,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.10",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
@@ -384,6 +477,335 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dioxus"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44c550c06b6785e16258ad620d5b559f5bbcbcc50e3c18c08aa6af2604a4c32"
+dependencies = [
+ "dioxus-config-macros",
+ "dioxus-core",
+ "dioxus-document",
+ "dioxus-history",
+ "dioxus-hooks",
+ "dioxus-router",
+ "dioxus-signals",
+ "dioxus-stores",
+ "dioxus-web",
+ "subsecond",
+]
+
+[[package]]
+name = "dioxus-cli-config"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c000f584ddf608e2b272b3074bf11512a474eeeb2eb85a1915f276ce5c4a8615"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "dioxus-config-macros"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54f9ed8fc1a215ad34bb8dbae42a4ea54efbcd26ca9006bbe5cca78e511bf25f"
+
+[[package]]
+name = "dioxus-core"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb3dd61889e6a09daec93d44db86047fb8e6603beedcf9351b8528582254e075"
+dependencies = [
+ "anyhow",
+ "const_format",
+ "dioxus-core-types",
+ "futures-channel",
+ "futures-util",
+ "generational-box",
+ "longest-increasing-subsequence",
+ "rustc-hash 2.1.2",
+ "rustversion",
+ "serde",
+ "slab",
+ "slotmap",
+ "subsecond",
+ "tracing",
+]
+
+[[package]]
+name = "dioxus-core-macro"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "370c63663dff0f24df5dfea643ca239283542c6b228a302f69b32e1d36762b7f"
+dependencies = [
+ "convert_case 0.8.0",
+ "dioxus-rsx",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dioxus-core-types"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36963eab106b169737762f9cd5ee5fd97f585989dcb2d8e30a596e97a6999009"
+
+[[package]]
+name = "dioxus-devtools"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27e7212436a581ce058d7554f1383916bd18a68ebd6015b0b4c2e9ecb0d5535"
+dependencies = [
+ "dioxus-cli-config",
+ "dioxus-core",
+ "dioxus-devtools-types",
+ "dioxus-signals",
+ "serde",
+ "serde_json",
+ "subsecond",
+ "thiserror",
+ "tracing",
+ "tungstenite",
+]
+
+[[package]]
+name = "dioxus-devtools-types"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aa24ed651b97e0b423270bf07a0f1b7dc0e0fa1f1dc26407cd2a118d6bf9de5"
+dependencies = [
+ "dioxus-core",
+ "serde",
+ "subsecond-types",
+]
+
+[[package]]
+name = "dioxus-document"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24685cb51cc6227ea606c49dfe531836f362c49183d3007241afcd8827498401"
+dependencies = [
+ "dioxus-core",
+ "dioxus-core-macro",
+ "dioxus-core-types",
+ "dioxus-html",
+ "futures-channel",
+ "futures-util",
+ "generational-box",
+ "lazy-js-bundle",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "dioxus-gtag"
+version = "0.1.0"
+dependencies = [
+ "by-macros",
+ "dioxus",
+ "serde_json",
+]
+
+[[package]]
+name = "dioxus-history"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010b446322b3f9176476579fa61c7552f0430abbeec418cab543482da6ca4363"
+dependencies = [
+ "dioxus-core",
+ "tracing",
+]
+
+[[package]]
+name = "dioxus-hooks"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e7a6ba279050cc161e1215c6db0bd15915c9314ec2916d7b22c113a3039536"
+dependencies = [
+ "dioxus-core",
+ "dioxus-signals",
+ "futures-channel",
+ "futures-util",
+ "generational-box",
+ "rustversion",
+ "slab",
+ "tracing",
+]
+
+[[package]]
+name = "dioxus-html"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0715e38cc6537aef5b79d0ddc1f4d7a56c2f4debe46b127eee24d8aa5dafd2d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "dioxus-core",
+ "dioxus-core-macro",
+ "dioxus-core-types",
+ "dioxus-hooks",
+ "dioxus-html-internal-macro",
+ "enumset",
+ "euclid",
+ "futures-channel",
+ "futures-util",
+ "generational-box",
+ "keyboard-types",
+ "lazy-js-bundle",
+ "rustversion",
+ "tracing",
+]
+
+[[package]]
+name = "dioxus-html-internal-macro"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "584e2772127ab00f0d5e1d4d9795f39fecebc828ece0b7a02349d438bc1b1ce7"
+dependencies = [
+ "convert_case 0.8.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dioxus-interpreter-js"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11999d6eb5bb179a9512dad30e5de408aab66f2cb65de9098c9fbe02927e2978"
+dependencies = [
+ "js-sys",
+ "lazy-js-bundle",
+ "rustc-hash 2.1.2",
+ "sledgehammer_bindgen",
+ "sledgehammer_utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "dioxus-router"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae50f5efa8d6f936c0c3bb85d7a55f6f19290f106290e331d1136d964e832fe6"
+dependencies = [
+ "dioxus-cli-config",
+ "dioxus-core",
+ "dioxus-core-macro",
+ "dioxus-history",
+ "dioxus-hooks",
+ "dioxus-html",
+ "dioxus-router-macro",
+ "dioxus-signals",
+ "percent-encoding",
+ "rustversion",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "dioxus-router-macro"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f83fb667d27e256f8c9eca49963fbace66a8722cb64ee15a10ffc97d092357e"
+dependencies = [
+ "base16",
+ "digest",
+ "proc-macro2",
+ "quote",
+ "sha2",
+ "slab",
+ "syn",
+]
+
+[[package]]
+name = "dioxus-rsx"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2106afda239a4c7c22ffa1ca19117011225fc1c735c139c0a5b765996aa8bb1d"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "dioxus-signals"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409bf65d243443416650945f22cd6caf2a6bb13ae0347a50ec5852adb1961072"
+dependencies = [
+ "dioxus-core",
+ "futures-channel",
+ "futures-util",
+ "generational-box",
+ "parking_lot",
+ "rustc-hash 2.1.2",
+ "tracing",
+ "warnings",
+]
+
+[[package]]
+name = "dioxus-stores"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245ec4f84348e5be77451bd204181998b8bc0995b48ff3adb2db0e0ec430dab4"
+dependencies = [
+ "dioxus-core",
+ "dioxus-signals",
+ "dioxus-stores-macro",
+ "generational-box",
+]
+
+[[package]]
+name = "dioxus-stores-macro"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a5875e9f890f27b1cc3e5b56c1e23601211470315a1fb8627c4ca4f3b2be9a"
+dependencies = [
+ "convert_case 0.8.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dioxus-web"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac92ef863bc5333440021e8ec3e538a39598c9c960daeaab66ab10ba940b5e0"
+dependencies = [
+ "dioxus-cli-config",
+ "dioxus-core",
+ "dioxus-core-types",
+ "dioxus-devtools",
+ "dioxus-document",
+ "dioxus-history",
+ "dioxus-html",
+ "dioxus-interpreter-js",
+ "dioxus-signals",
+ "futures-channel",
+ "futures-util",
+ "generational-box",
+ "js-sys",
+ "lazy-js-bundle",
+ "rustc-hash 2.1.2",
+ "send_wrapper",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
 ]
 
 [[package]]
@@ -434,6 +856,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumset"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839c4174b41e75c8f7306110b2c51996a293b8d1d850edd529011841d9fede7d"
+dependencies = [
+ "enumset_derive",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd536557b58c682b217b8fb199afdff47cd3eff260623f19e77074eb073d63a"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +901,15 @@ dependencies = [
  "cfg-if",
  "home",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -523,9 +975,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -533,9 +985,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
@@ -566,10 +1018,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
-name = "futures-sink"
+name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -585,12 +1048,23 @@ checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generational-box"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cd0d825b8d339701ad330dbcd6399519ced4d143484954daf6e3185dace4f77"
+dependencies = [
+ "parking_lot",
+ "tracing",
 ]
 
 [[package]]
@@ -1044,13 +1518,44 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "keyboard-types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
+name = "lazy-js-bundle"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccafada6c9541db44db758619236f2748f6e1bdaa84d04ded858567cd1e89321"
 
 [[package]]
 name = "lazy_static"
@@ -1066,6 +1571,16 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libm"
@@ -1098,11 +1613,10 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -1111,6 +1625,12 @@ name = "log"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+
+[[package]]
+name = "longest-increasing-subsequence"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3bd0dd2cd90571056fdb71f6275fada10131182f84899f4b2a916e565d81d86"
 
 [[package]]
 name = "lru-slab"
@@ -1142,6 +1662,24 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mime"
@@ -1271,9 +1809,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1281,15 +1819,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -1306,6 +1844,26 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1379,11 +1937,23 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
 ]
 
 [[package]]
@@ -1397,9 +1967,9 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.8",
+ "socket2 0.6.4",
  "thiserror",
  "tokio",
  "tracing",
@@ -1418,7 +1988,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -1437,7 +2007,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.8",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -1663,6 +2233,12 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
@@ -1742,7 +2318,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1765,9 +2341,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -1855,6 +2431,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,6 +2447,17 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1932,9 +2528,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1993,11 +2589,47 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "sledgehammer_bindgen"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e83e178d176459c92bc129cfd0958afac3ced925471b889b3a75546cfc4133"
 dependencies = [
- "autocfg",
+ "sledgehammer_bindgen_macro",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "sledgehammer_bindgen_macro"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb251b407f50028476a600541542b605bb864d35d9ee1de4f6cab45d88475e6d"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sledgehammer_utils"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "debdd4b83524961983cea3c55383b3910fd2f24fd13a188f5b091d2d504a61ae"
+dependencies = [
+ "rustc-hash 1.1.0",
+]
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "serde",
+ "version_check",
 ]
 
 [[package]]
@@ -2263,6 +2895,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subsecond"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cc79674bd55726e6b123204403389400229a95fe4a3b2c5453dada70b06ca95"
+dependencies = [
+ "js-sys",
+ "libc",
+ "libloading",
+ "memfd",
+ "memmap2",
+ "serde",
+ "subsecond-types",
+ "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "subsecond-types"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9798bfed58797aed51c672aa99810aac30a50d3120ecfdcf28c13784e9a8f1c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2270,9 +2930,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2566,6 +3226,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2605,6 +3282,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2620,6 +3303,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf16_iter"
@@ -2661,7 +3350,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
 dependencies = [
- "darling",
+ "darling 0.20.10",
  "once_cell",
  "proc-macro-error2",
  "proc-macro2",
@@ -2707,6 +3396,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "warnings"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f68998838dab65727c9b30465595c6f7c953313559371ca8bf31759b3680ad"
+dependencies = [
+ "pin-project",
+ "tracing",
+ "warnings-macro",
+]
+
+[[package]]
+name = "warnings-macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59195a1db0e95b920366d949ba5e0d3fc0e70b67c09be15ce5abb790106b0571"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2729,48 +3440,32 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2778,31 +3473,44 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.77"
+name = "wasm-streams"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PACKAGES=by-macros dioxus-gtag
+PACKAGES=by-macros dioxus-gtag-macro dioxus-gtag
 
 setup:
 	cargo install mdbook

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PACKAGES=by-macros
+PACKAGES=by-macros dioxus-gtag
 
 setup:
 	cargo install mdbook

--- a/packages/by-macros/Cargo.toml
+++ b/packages/by-macros/Cargo.toml
@@ -27,6 +27,11 @@ validator = { version = "0.20.0", features = ["derive"] }
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+# Test fixtures reference by-types/by-axum/rest-api versions that were removed
+# from the workspace before being published, so pin the last workspace state.
+by-axum = { git = "https://github.com/biyard/rust-sdk.git", rev = "fdb8ab49bd08fd9ff263fe11381038c6d45d4ef9" }
+by-types = { git = "https://github.com/biyard/rust-sdk.git", rev = "fdb8ab49bd08fd9ff263fe11381038c6d45d4ef9" }
+rest-api = { git = "https://github.com/biyard/rust-sdk.git", rev = "fdb8ab49bd08fd9ff263fe11381038c6d45d4ef9" }
 reqwest = "0.13"
 schemars.workspace = true
 tokio = { version = "1.43.0", features = ["full"] }

--- a/packages/by-macros/Cargo.toml
+++ b/packages/by-macros/Cargo.toml
@@ -27,8 +27,9 @@ validator = { version = "0.20.0", features = ["derive"] }
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-# Test fixtures reference by-types/by-axum/rest-api versions that were removed
-# from the workspace before being published, so pin the last workspace state.
+# The test fixtures depend on by-types/by-axum/rest-api versions that were
+# removed from the workspace before being published, so pin the last
+# workspace state.
 by-axum = { git = "https://github.com/biyard/rust-sdk.git", rev = "fdb8ab49bd08fd9ff263fe11381038c6d45d4ef9" }
 by-types = { git = "https://github.com/biyard/rust-sdk.git", rev = "fdb8ab49bd08fd9ff263fe11381038c6d45d4ef9" }
 rest-api = { git = "https://github.com/biyard/rust-sdk.git", rev = "fdb8ab49bd08fd9ff263fe11381038c6d45d4ef9" }

--- a/packages/dioxus-gtag-macro/Cargo.toml
+++ b/packages/dioxus-gtag-macro/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "dioxus-gtag-macro"
+version = "0.1.0"
+edition = "2021"
+description = "Derive macro for dioxus-gtag typed events"
+license = "Apache-2.0"
+keywords = ["dioxus", "analytics", "gtag", "macros"]
+repository = "https://github.com/biyard/rust-sdk/tree/main/packages/dioxus-gtag-macro"
+authors.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }

--- a/packages/dioxus-gtag-macro/src/lib.rs
+++ b/packages/dioxus-gtag-macro/src/lib.rs
@@ -109,11 +109,24 @@ pub fn derive_gtag_event(input: TokenStream) -> TokenStream {
         if skip {
             continue;
         }
+        // Fail fast in debug builds so serialization bugs surface during
+        // testing; in release, analytics must never take the app down, so
+        // fall back to null.
         inserts.push(quote! {
             params.insert(
                 #key.to_string(),
-                ::dioxus_gtag::__private::serde_json::to_value(&self.#ident)
-                    .unwrap_or(::dioxus_gtag::__private::serde_json::Value::Null),
+                match ::dioxus_gtag::__private::serde_json::to_value(&self.#ident) {
+                    Ok(value) => value,
+                    Err(err) => {
+                        if cfg!(debug_assertions) {
+                            panic!(
+                                "GtagEvent: failed to serialize param `{}`: {}",
+                                #key, err
+                            );
+                        }
+                        ::dioxus_gtag::__private::serde_json::Value::Null
+                    }
+                },
             );
         });
     }

--- a/packages/dioxus-gtag-macro/src/lib.rs
+++ b/packages/dioxus-gtag-macro/src/lib.rs
@@ -1,0 +1,150 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Data, DeriveInput, Fields, LitStr};
+
+/// Derives `dioxus_gtag::GtagEvent`, turning a struct into a typed GA4 event.
+///
+/// The event name defaults to the snake_case struct name and can be overridden
+/// with `#[gtag(name = "…")]`. Each field becomes an event param via serde
+/// serialization (so every field type must implement `serde::Serialize`);
+/// `#[gtag(rename = "…")]` changes a param key and `#[gtag(skip)]` omits a
+/// field.
+///
+/// ```rust,ignore
+/// #[derive(GtagEvent)]
+/// #[gtag(name = "purchase")]
+/// pub struct Purchase {
+///     pub value: f64,
+///     pub currency: String,
+///     #[gtag(rename = "item_id")]
+///     pub sku: String,
+///     #[gtag(skip)]
+///     pub internal: bool,
+/// }
+///
+/// gtag.send(&Purchase { … });
+/// ```
+#[proc_macro_derive(GtagEvent, attributes(gtag))]
+pub fn derive_gtag_event(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let struct_name = &input.ident;
+
+    let mut event_name: Option<String> = None;
+    for attr in &input.attrs {
+        if attr.path().is_ident("gtag") {
+            let parsed = attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("name") {
+                    let lit: LitStr = meta.value()?.parse()?;
+                    event_name = Some(lit.value());
+                    Ok(())
+                } else {
+                    Err(meta.error("unsupported gtag attribute; expected `name`"))
+                }
+            });
+            if let Err(e) = parsed {
+                return e.to_compile_error().into();
+            }
+        }
+    }
+    let event_name = event_name.unwrap_or_else(|| to_snake_case(&struct_name.to_string()));
+
+    let fields = match &input.data {
+        Data::Struct(data) => match &data.fields {
+            Fields::Named(named) => &named.named,
+            Fields::Unit => {
+                return quote! {
+                    impl ::dioxus_gtag::GtagEvent for #struct_name {
+                        fn event_name(&self) -> &str { #event_name }
+                        fn params(&self) -> ::dioxus_gtag::__private::serde_json::Value {
+                            ::dioxus_gtag::__private::serde_json::Value::Object(
+                                ::dioxus_gtag::__private::serde_json::Map::new(),
+                            )
+                        }
+                    }
+                }
+                .into()
+            }
+            _ => {
+                return syn::Error::new_spanned(
+                    struct_name,
+                    "GtagEvent requires named fields or a unit struct",
+                )
+                .to_compile_error()
+                .into()
+            }
+        },
+        _ => {
+            return syn::Error::new_spanned(struct_name, "GtagEvent can only be derived for structs")
+                .to_compile_error()
+                .into()
+        }
+    };
+
+    let mut inserts = vec![];
+    for field in fields {
+        let ident = field.ident.as_ref().unwrap();
+        let mut key = ident.to_string();
+        let mut skip = false;
+        for attr in &field.attrs {
+            if attr.path().is_ident("gtag") {
+                let parsed = attr.parse_nested_meta(|meta| {
+                    if meta.path.is_ident("rename") {
+                        let lit: LitStr = meta.value()?.parse()?;
+                        key = lit.value();
+                        Ok(())
+                    } else if meta.path.is_ident("skip") {
+                        skip = true;
+                        Ok(())
+                    } else {
+                        Err(meta.error("unsupported gtag attribute; expected `rename` or `skip`"))
+                    }
+                });
+                if let Err(e) = parsed {
+                    return e.to_compile_error().into();
+                }
+            }
+        }
+        if skip {
+            continue;
+        }
+        inserts.push(quote! {
+            params.insert(
+                #key.to_string(),
+                ::dioxus_gtag::__private::serde_json::to_value(&self.#ident)
+                    .unwrap_or(::dioxus_gtag::__private::serde_json::Value::Null),
+            );
+        });
+    }
+
+    quote! {
+        impl ::dioxus_gtag::GtagEvent for #struct_name {
+            fn event_name(&self) -> &str {
+                #event_name
+            }
+
+            fn params(&self) -> ::dioxus_gtag::__private::serde_json::Value {
+                let mut params = ::dioxus_gtag::__private::serde_json::Map::new();
+                #(#inserts)*
+                ::dioxus_gtag::__private::serde_json::Value::Object(params)
+            }
+        }
+    }
+    .into()
+}
+
+fn to_snake_case(name: &str) -> String {
+    let mut out = String::with_capacity(name.len() + 4);
+    for (i, c) in name.chars().enumerate() {
+        if c.is_uppercase() {
+            if i > 0 {
+                out.push('_');
+            }
+            out.extend(c.to_lowercase());
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}

--- a/packages/dioxus-gtag/Cargo.toml
+++ b/packages/dioxus-gtag/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "dioxus-gtag"
+version = "0.1.0"
+edition = "2021"
+description = "Google Analytics (gtag.js) context provider and hooks for Dioxus"
+license = "Apache-2.0"
+keywords = ["dioxus", "analytics", "gtag", "google-analytics"]
+repository = "https://github.com/biyard/rust-sdk/tree/main/packages/dioxus-gtag"
+authors.workspace = true
+
+[dependencies]
+by-macros.workspace = true
+serde_json.workspace = true
+dioxus = { version = "0.7", default-features = false, features = [
+    "signals",
+    "hooks",
+    "document",
+] }
+
+[features]
+default = []
+router = ["dioxus/router"]

--- a/packages/dioxus-gtag/Cargo.toml
+++ b/packages/dioxus-gtag/Cargo.toml
@@ -10,6 +10,7 @@ authors.workspace = true
 
 [dependencies]
 by-macros.workspace = true
+dioxus-gtag-macro = { path = "../dioxus-gtag-macro", version = "0.1.0" }
 serde_json.workspace = true
 dioxus = { version = "0.7", default-features = false, features = [
     "signals",

--- a/packages/dioxus-gtag/README.md
+++ b/packages/dioxus-gtag/README.md
@@ -1,0 +1,131 @@
+# dioxus-gtag
+
+Google Analytics 4 (gtag.js) integration for Dioxus.
+
+- No `index.html` edits — the provider injects gtag.js via `document::eval`
+- SSR/fullstack safe — initialization runs in an effect, so it only happens on the client
+- Works on web and desktop (webview); no `#[cfg]` needed at call sites
+- Events fired before gtag.js is ready are buffered and flushed on initialization
+- Consent Mode v2, `user_id`/user properties, runtime opt-in/opt-out
+- Optional `router` feature for automatic `page_view` on route changes
+
+## Setup
+
+```toml
+[dependencies]
+dioxus-gtag = { version = "0.1", features = ["router"] }
+```
+
+Provide the context once at the App root, like other context providers:
+
+```rust
+use dioxus::prelude::*;
+use dioxus_gtag::prelude::*;
+
+#[component]
+pub fn App() -> Element {
+    use_gtag_context_provider("G-XXXXXXXXXX");
+
+    rsx! { Router::<Route> {} }
+}
+```
+
+For more control, use `GtagConfig`:
+
+```rust
+use_gtag_context_provider_with(
+    GtagConfig::new("G-XXXXXXXXXX")
+        .debug(cfg!(debug_assertions))          // events show in GA4 DebugView
+        .default_consent(ConsentUpdate::deny_all()) // Consent Mode v2 default
+        .enabled(false),                        // opt-in flow: load nothing until consent
+);
+```
+
+## Sending events
+
+In a component or controller (hook context), use `use_gtag_context()`:
+
+```rust
+#[derive(Debug, Clone, Copy, DioxusController)]
+pub struct Controller {
+    gtag: UseGtagContext,
+}
+
+impl Controller {
+    pub fn new(lang: Language) -> std::result::Result<Self, RenderError> {
+        Ok(Self { gtag: use_gtag_context() })
+    }
+
+    pub fn on_submit(&self) {
+        self.gtag.event("quiz_submit", &[("lang", "ko".into())]);
+    }
+}
+```
+
+In `spawn` or event handler closures (non-hook context), use `consume_gtag_context()`:
+
+```rust
+rsx! {
+    button {
+        onclick: move |_| {
+            consume_gtag_context()
+                .event("purchase", &[("currency", "KRW".into()), ("value", 12000.into())]);
+        },
+        "Buy"
+    }
+}
+```
+
+For nested payloads (e.g. GA4 `items` arrays), use `event_json`:
+
+```rust
+gtag.event_json("purchase", serde_json::json!({
+    "currency": "KRW",
+    "value": 12000,
+    "items": [{ "item_id": "SKU_1", "quantity": 1 }],
+}));
+```
+
+## Automatic page views (`router` feature)
+
+Call `use_gtag_page_view()` once in the root layout, inside the `Router`:
+
+```rust
+#[component]
+pub fn RootLayout() -> Element {
+    use_gtag_page_view();
+
+    rsx! { Outlet::<Route> {} }
+}
+```
+
+The provider configures gtag with `send_page_view: false` by default, so the
+hook's page views are not double-counted. If you do not use the hook and want
+gtag's own automatic initial page view instead, opt in with
+`GtagConfig::send_page_view(true)`.
+
+## Consent and opt-out
+
+```rust
+// Consent Mode v2 update after the user accepts analytics cookies
+gtag.consent(ConsentUpdate::new().analytics_storage(ConsentStatus::Granted));
+
+// Identify the signed-in user (None clears it)
+gtag.set_user_id(Some("user-123"));
+gtag.set_user_property("plan", "pro".into());
+
+// Runtime kill switch: drops all subsequent calls and sets GA's
+// `ga-disable-{id}` flag. Re-enabling bootstraps gtag.js if it was
+// never loaded (opt-in flows starting from `GtagConfig::enabled(false)`).
+gtag.set_enabled(false);
+```
+
+## API summary
+
+| Function | Hook? | Call site |
+|----------|-------|-----------|
+| `use_gtag_context_provider(id)` / `_with(config)` | Yes | App root |
+| `use_gtag_context()` | Yes | Component/hook body |
+| `consume_gtag_context()` | No | `spawn`, event closures |
+| `provide_gtag_context(ctx)` | No | Conditional provides, tests |
+| `use_gtag_page_view()` (`router` feature) | Yes | Root layout inside `Router` |

--- a/packages/dioxus-gtag/README.md
+++ b/packages/dioxus-gtag/README.md
@@ -76,7 +76,37 @@ rsx! {
 }
 ```
 
-For nested payloads (e.g. GA4 `items` arrays), use `event_json`:
+### Typed events
+
+Define events as structs with `#[derive(GtagEvent)]` and send them with
+`send` — the event name defaults to the snake_case struct name:
+
+```rust
+use dioxus_gtag::GtagEvent;
+
+#[derive(GtagEvent)]
+#[gtag(name = "purchase")]              // optional; defaults to "purchase" anyway
+pub struct Purchase {
+    pub value: f64,
+    pub currency: String,
+    #[gtag(rename = "item_id")]         // param key override
+    pub sku: String,
+    #[gtag(skip)]                       // not sent
+    pub internal: bool,
+}
+
+gtag.send(&Purchase {
+    value: 12000.0,
+    currency: "KRW".to_string(),
+    sku: "SKU_1".to_string(),
+    internal: true,
+});
+```
+
+Field values are serialized with serde, so nested types work as long as they
+implement `serde::Serialize`.
+
+For ad-hoc nested payloads (e.g. GA4 `items` arrays), use `event_json`:
 
 ```rust
 gtag.event_json("purchase", serde_json::json!({

--- a/packages/dioxus-gtag/src/config.rs
+++ b/packages/dioxus-gtag/src/config.rs
@@ -1,0 +1,58 @@
+use crate::consent::ConsentUpdate;
+
+/// Configuration for the gtag context.
+///
+/// ```rust
+/// use dioxus_gtag::GtagConfig;
+///
+/// let config = GtagConfig::new("G-XXXXXXXXXX")
+///     .debug(cfg!(debug_assertions))
+///     .enabled(true);
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct GtagConfig {
+    pub measurement_id: String,
+    /// Whether gtag.js sends its automatic initial `page_view`.
+    /// Defaults to `false` so that `use_gtag_page_view`/manual `page_view`
+    /// calls do not double-count.
+    pub send_page_view: bool,
+    /// Attaches `debug_mode: true` so events show up in GA4 DebugView.
+    pub debug_mode: bool,
+    /// When `false`, gtag.js is not loaded and all calls are dropped until
+    /// `set_enabled(true)` is called (e.g. after user opt-in).
+    pub enabled: bool,
+    /// Consent state declared before `gtag('config', …)`, per Consent Mode v2.
+    pub default_consent: Option<ConsentUpdate>,
+}
+
+impl GtagConfig {
+    pub fn new(measurement_id: impl Into<String>) -> Self {
+        Self {
+            measurement_id: measurement_id.into(),
+            send_page_view: false,
+            debug_mode: false,
+            enabled: true,
+            default_consent: None,
+        }
+    }
+
+    pub fn send_page_view(mut self, on: bool) -> Self {
+        self.send_page_view = on;
+        self
+    }
+
+    pub fn debug(mut self, on: bool) -> Self {
+        self.debug_mode = on;
+        self
+    }
+
+    pub fn enabled(mut self, on: bool) -> Self {
+        self.enabled = on;
+        self
+    }
+
+    pub fn default_consent(mut self, consent: ConsentUpdate) -> Self {
+        self.default_consent = Some(consent);
+        self
+    }
+}

--- a/packages/dioxus-gtag/src/consent.rs
+++ b/packages/dioxus-gtag/src/consent.rs
@@ -1,0 +1,90 @@
+/// Consent state for a single consent type, as defined by Google Consent Mode v2.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConsentStatus {
+    Granted,
+    Denied,
+}
+
+impl ConsentStatus {
+    fn as_str(&self) -> &'static str {
+        match self {
+            ConsentStatus::Granted => "granted",
+            ConsentStatus::Denied => "denied",
+        }
+    }
+}
+
+/// A consent update for Google Consent Mode v2.
+///
+/// Only the fields set to `Some` are included in the `gtag('consent', …)` call,
+/// so an update can change one consent type without touching the others.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ConsentUpdate {
+    pub ad_storage: Option<ConsentStatus>,
+    pub analytics_storage: Option<ConsentStatus>,
+    pub ad_user_data: Option<ConsentStatus>,
+    pub ad_personalization: Option<ConsentStatus>,
+}
+
+impl ConsentUpdate {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn grant_all() -> Self {
+        Self {
+            ad_storage: Some(ConsentStatus::Granted),
+            analytics_storage: Some(ConsentStatus::Granted),
+            ad_user_data: Some(ConsentStatus::Granted),
+            ad_personalization: Some(ConsentStatus::Granted),
+        }
+    }
+
+    pub fn deny_all() -> Self {
+        Self {
+            ad_storage: Some(ConsentStatus::Denied),
+            analytics_storage: Some(ConsentStatus::Denied),
+            ad_user_data: Some(ConsentStatus::Denied),
+            ad_personalization: Some(ConsentStatus::Denied),
+        }
+    }
+
+    pub fn ad_storage(mut self, status: ConsentStatus) -> Self {
+        self.ad_storage = Some(status);
+        self
+    }
+
+    pub fn analytics_storage(mut self, status: ConsentStatus) -> Self {
+        self.analytics_storage = Some(status);
+        self
+    }
+
+    pub fn ad_user_data(mut self, status: ConsentStatus) -> Self {
+        self.ad_user_data = Some(status);
+        self
+    }
+
+    pub fn ad_personalization(mut self, status: ConsentStatus) -> Self {
+        self.ad_personalization = Some(status);
+        self
+    }
+
+    pub(crate) fn to_json(self) -> serde_json::Value {
+        let mut map = serde_json::Map::new();
+        let fields = [
+            ("ad_storage", self.ad_storage),
+            ("analytics_storage", self.analytics_storage),
+            ("ad_user_data", self.ad_user_data),
+            ("ad_personalization", self.ad_personalization),
+        ];
+        for (key, status) in fields {
+            if let Some(status) = status {
+                map.insert(
+                    key.to_string(),
+                    serde_json::Value::String(status.as_str().to_string()),
+                );
+            }
+        }
+        serde_json::Value::Object(map)
+    }
+}

--- a/packages/dioxus-gtag/src/context.rs
+++ b/packages/dioxus-gtag/src/context.rs
@@ -1,0 +1,157 @@
+use by_macros::DioxusController;
+use dioxus::prelude::*;
+
+use crate::config::GtagConfig;
+use crate::consent::ConsentUpdate;
+use crate::js;
+use crate::value::{params_to_json, GtagValue};
+
+/// App-wide Google Analytics context.
+///
+/// Provide it once at the App root with [`use_gtag_context_provider`], then
+/// read it with [`use_gtag_context`] (components/hooks) or
+/// [`consume_gtag_context`] (spawn/event closures).
+#[derive(Clone, Copy, DioxusController)]
+pub struct UseGtagContext {
+    config: Signal<GtagConfig>,
+    enabled: Signal<bool>,
+    initialized: Signal<bool>,
+    pending: Signal<Vec<String>>,
+}
+
+/// Hook — call once at the App root (before `Router`), like other context
+/// providers. Injects gtag.js and registers the context.
+///
+/// ```rust,ignore
+/// #[component]
+/// pub fn App() -> Element {
+///     use_gtag_context_provider("G-XXXXXXXXXX");
+///     rsx! { Router::<Route> {} }
+/// }
+/// ```
+pub fn use_gtag_context_provider(measurement_id: &str) -> UseGtagContext {
+    use_gtag_context_provider_with(GtagConfig::new(measurement_id))
+}
+
+/// Hook — same as [`use_gtag_context_provider`] but with full [`GtagConfig`]
+/// control (debug mode, default consent, opt-in flows, …).
+pub fn use_gtag_context_provider_with(config: GtagConfig) -> UseGtagContext {
+    let enabled = config.enabled;
+    let ctx = use_context_provider(|| UseGtagContext {
+        config: Signal::new(config),
+        enabled: Signal::new(enabled),
+        initialized: Signal::new(false),
+        pending: Signal::new(Vec::new()),
+    });
+
+    // Effects only run on the client, so gtag.js is never touched during SSR.
+    // Reading `enabled` subscribes the effect, so a later `set_enabled(true)`
+    // (user opt-in) triggers initialization.
+    use_effect(move || {
+        if *ctx.enabled.read() {
+            ctx.init();
+        }
+    });
+
+    ctx
+}
+
+/// Hook — component or hook body.
+pub fn use_gtag_context() -> UseGtagContext {
+    use_context::<UseGtagContext>()
+}
+
+/// Non-hook — `spawn`, event handler closures, and other non-hook call sites.
+pub fn consume_gtag_context() -> UseGtagContext {
+    consume_context::<UseGtagContext>()
+}
+
+/// Non-hook — conditional provides and test setup.
+pub fn provide_gtag_context(ctx: UseGtagContext) -> UseGtagContext {
+    provide_context(ctx)
+}
+
+impl UseGtagContext {
+    /// Sends a GA4 event: `gtag('event', name, params)`.
+    ///
+    /// Calls made before gtag.js is bootstrapped are buffered and flushed on
+    /// initialization; calls made while disabled are dropped.
+    pub fn event(&self, name: &str, params: &[(&str, GtagValue)]) {
+        self.push(js::event(name, &params_to_json(params)));
+    }
+
+    /// Sends a GA4 event with arbitrary JSON params, for payloads that do not
+    /// fit the `&[(&str, GtagValue)]` shape (nested items arrays, …).
+    pub fn event_json(&self, name: &str, params: serde_json::Value) {
+        self.push(js::event(name, &params));
+    }
+
+    /// Sends a `page_view` event. With the `router` feature,
+    /// `use_gtag_page_view` calls this automatically on route changes.
+    pub fn page_view(&self, path: &str, title: Option<&str>) {
+        self.push(js::page_view(path, title));
+    }
+
+    /// Sets (or clears, with `None`) the GA4 `user_id` for subsequent events.
+    pub fn set_user_id(&self, id: Option<&str>) {
+        self.push(js::set_user_id(id));
+    }
+
+    /// Sets a GA4 user property for subsequent events.
+    pub fn set_user_property(&self, key: &str, value: GtagValue) {
+        self.push(js::set_user_property(key, &value.to_json()));
+    }
+
+    /// Sends a Consent Mode v2 update: `gtag('consent', 'update', …)`.
+    pub fn consent(&self, update: ConsentUpdate) {
+        self.push(js::consent_update(&update));
+    }
+
+    /// Runtime opt-in/opt-out toggle. Disabling sets GA's `ga-disable-{id}`
+    /// kill switch and drops subsequent calls; enabling bootstraps gtag.js if
+    /// it has not been loaded yet (opt-in consent flows).
+    pub fn set_enabled(&self, on: bool) {
+        let mut enabled = self.enabled;
+        enabled.set(on);
+        if *self.initialized.peek() {
+            let id = self.config.peek().measurement_id.clone();
+            document::eval(&js::set_disabled(&id, !on));
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        *self.enabled.peek()
+    }
+
+    fn init(&self) {
+        if *self.initialized.peek() {
+            // Re-enabled after an opt-out: lift the kill switch again.
+            let id = self.config.peek().measurement_id.clone();
+            document::eval(&js::set_disabled(&id, false));
+            return;
+        }
+
+        document::eval(&js::bootstrap(&self.config.peek()));
+
+        let mut initialized = self.initialized;
+        initialized.set(true);
+
+        let mut pending = self.pending;
+        let buffered: Vec<String> = pending.write().drain(..).collect();
+        for script in buffered {
+            document::eval(&script);
+        }
+    }
+
+    fn push(&self, script: String) {
+        if !*self.enabled.peek() {
+            return;
+        }
+        if *self.initialized.peek() {
+            document::eval(&script);
+        } else {
+            let mut pending = self.pending;
+            pending.write().push(script);
+        }
+    }
+}

--- a/packages/dioxus-gtag/src/context.rs
+++ b/packages/dioxus-gtag/src/context.rs
@@ -86,6 +86,19 @@ impl UseGtagContext {
         self.push(js::event(name, &params));
     }
 
+    /// Sends a typed event defined with `#[derive(GtagEvent)]`.
+    ///
+    /// ```rust,ignore
+    /// #[derive(GtagEvent)]
+    /// #[gtag(name = "purchase")]
+    /// struct Purchase { value: f64, currency: String }
+    ///
+    /// gtag.send(&Purchase { value: 12000.0, currency: "KRW".into() });
+    /// ```
+    pub fn send(&self, event: &impl crate::GtagEvent) {
+        self.push(js::event(event.event_name(), &event.params()));
+    }
+
     /// Sends a `page_view` event. With the `router` feature,
     /// `use_gtag_page_view` calls this automatically on route changes.
     pub fn page_view(&self, path: &str, title: Option<&str>) {

--- a/packages/dioxus-gtag/src/event.rs
+++ b/packages/dioxus-gtag/src/event.rs
@@ -1,0 +1,24 @@
+/// A typed GA4 event, usually implemented via `#[derive(GtagEvent)]`:
+///
+/// ```rust
+/// use dioxus_gtag::GtagEvent;
+///
+/// #[derive(GtagEvent)]
+/// #[gtag(name = "purchase")]
+/// pub struct Purchase {
+///     pub value: f64,
+///     pub currency: String,
+/// }
+///
+/// let event = Purchase { value: 12000.0, currency: "KRW".to_string() };
+/// assert_eq!(event.event_name(), "purchase");
+/// ```
+///
+/// Send it with [`UseGtagContext::send`](crate::UseGtagContext::send).
+pub trait GtagEvent {
+    /// The GA4 event name, e.g. `"purchase"`.
+    fn event_name(&self) -> &str;
+
+    /// The event params as a JSON object.
+    fn params(&self) -> serde_json::Value;
+}

--- a/packages/dioxus-gtag/src/js.rs
+++ b/packages/dioxus-gtag/src/js.rs
@@ -1,0 +1,169 @@
+//! Pure builders for the JavaScript snippets sent to `document::eval`.
+//!
+//! Kept free of Dioxus types so they can be unit-tested without a runtime.
+//! All dynamic strings are embedded via `serde_json` serialization, which
+//! yields properly quoted and escaped JS string literals.
+
+use crate::config::GtagConfig;
+use crate::consent::ConsentUpdate;
+
+fn js_string(s: &str) -> String {
+    serde_json::to_string(s).expect("string serialization cannot fail")
+}
+
+/// The bootstrap snippet: defines `dataLayer`/`gtag`, declares default
+/// consent, configures the measurement id, and injects the gtag.js script
+/// tag exactly once.
+pub(crate) fn bootstrap(config: &GtagConfig) -> String {
+    let id = js_string(&config.measurement_id);
+
+    let consent = match &config.default_consent {
+        Some(update) => format!("gtag('consent', 'default', {});\n", update.to_json()),
+        None => String::new(),
+    };
+
+    let mut params = serde_json::Map::new();
+    params.insert(
+        "send_page_view".to_string(),
+        serde_json::Value::Bool(config.send_page_view),
+    );
+    if config.debug_mode {
+        params.insert("debug_mode".to_string(), serde_json::Value::Bool(true));
+    }
+    let params = serde_json::Value::Object(params);
+
+    format!(
+        r#"window.dataLayer = window.dataLayer || [];
+window.gtag = window.gtag || function() {{ window.dataLayer.push(arguments); }};
+gtag('js', new Date());
+{consent}gtag('config', {id}, {params});
+if (!document.getElementById('dioxus-gtag-js')) {{
+    var s = document.createElement('script');
+    s.id = 'dioxus-gtag-js';
+    s.async = true;
+    s.src = 'https://www.googletagmanager.com/gtag/js?id=' + encodeURIComponent({id});
+    document.head.appendChild(s);
+}}"#
+    )
+}
+
+pub(crate) fn event(name: &str, params: &serde_json::Value) -> String {
+    format!("gtag('event', {}, {});", js_string(name), params)
+}
+
+pub(crate) fn page_view(path: &str, title: Option<&str>) -> String {
+    let mut params = serde_json::Map::new();
+    params.insert(
+        "page_path".to_string(),
+        serde_json::Value::String(path.to_string()),
+    );
+    if let Some(title) = title {
+        params.insert(
+            "page_title".to_string(),
+            serde_json::Value::String(title.to_string()),
+        );
+    }
+    event("page_view", &serde_json::Value::Object(params))
+}
+
+pub(crate) fn set_user_id(id: Option<&str>) -> String {
+    let value = match id {
+        Some(id) => js_string(id),
+        None => "null".to_string(),
+    };
+    format!("gtag('set', {{ 'user_id': {value} }});")
+}
+
+pub(crate) fn set_user_property(key: &str, value: &serde_json::Value) -> String {
+    format!(
+        "gtag('set', 'user_properties', {{ {}: {} }});",
+        js_string(key),
+        value
+    )
+}
+
+pub(crate) fn consent_update(update: &ConsentUpdate) -> String {
+    format!("gtag('consent', 'update', {});", update.to_json())
+}
+
+/// Toggles Google Analytics' library-level kill switch for a measurement id.
+pub(crate) fn set_disabled(measurement_id: &str, disabled: bool) -> String {
+    format!(
+        "window['ga-disable-' + {}] = {disabled};",
+        js_string(measurement_id)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::consent::{ConsentStatus, ConsentUpdate};
+    use crate::value::{params_to_json, GtagValue};
+
+    #[test]
+    fn bootstrap_contains_config_and_script() {
+        let config = GtagConfig::new("G-TEST123").debug(true);
+        let js = bootstrap(&config);
+        assert!(js.contains(r#"gtag('config', "G-TEST123", {"debug_mode":true,"send_page_view":false});"#));
+        assert!(js.contains("googletagmanager.com/gtag/js"));
+        assert!(!js.contains("gtag('consent', 'default'"));
+    }
+
+    #[test]
+    fn bootstrap_declares_default_consent_before_config() {
+        let config =
+            GtagConfig::new("G-TEST123").default_consent(ConsentUpdate::deny_all());
+        let js = bootstrap(&config);
+        let consent_pos = js.find("gtag('consent', 'default'").unwrap();
+        let config_pos = js.find("gtag('config'").unwrap();
+        assert!(consent_pos < config_pos);
+    }
+
+    #[test]
+    fn event_escapes_name_and_params() {
+        let params = params_to_json(&[
+            ("currency", "KRW".into()),
+            ("value", 12000.into()),
+            ("note", GtagValue::from("has \"quotes\"")),
+        ]);
+        let js = event("purchase", &params);
+        assert_eq!(
+            js,
+            r#"gtag('event', "purchase", {"currency":"KRW","note":"has \"quotes\"","value":12000});"#
+        );
+    }
+
+    #[test]
+    fn page_view_with_title() {
+        assert_eq!(
+            page_view("/ko/main", Some("Main")),
+            r#"gtag('event', "page_view", {"page_path":"/ko/main","page_title":"Main"});"#
+        );
+    }
+
+    #[test]
+    fn user_id_can_be_cleared() {
+        assert_eq!(
+            set_user_id(Some("user-1")),
+            r#"gtag('set', { 'user_id': "user-1" });"#
+        );
+        assert_eq!(set_user_id(None), "gtag('set', { 'user_id': null });");
+    }
+
+    #[test]
+    fn consent_update_only_includes_set_fields() {
+        let update = ConsentUpdate::new().analytics_storage(ConsentStatus::Granted);
+        assert_eq!(
+            consent_update(&update),
+            r#"gtag('consent', 'update', {"analytics_storage":"granted"});"#
+        );
+    }
+
+    #[test]
+    fn disable_flag_uses_measurement_id() {
+        assert_eq!(
+            set_disabled("G-TEST123", true),
+            r#"window['ga-disable-' + "G-TEST123"] = true;"#
+        );
+    }
+}

--- a/packages/dioxus-gtag/src/lib.rs
+++ b/packages/dioxus-gtag/src/lib.rs
@@ -37,6 +37,7 @@
 mod config;
 mod consent;
 mod context;
+mod event;
 mod js;
 #[cfg(feature = "router")]
 mod router;
@@ -48,9 +49,17 @@ pub use context::{
     consume_gtag_context, provide_gtag_context, use_gtag_context, use_gtag_context_provider,
     use_gtag_context_provider_with, UseGtagContext,
 };
+pub use dioxus_gtag_macro::GtagEvent;
+pub use event::GtagEvent;
 #[cfg(feature = "router")]
 pub use router::use_gtag_page_view;
 pub use value::GtagValue;
+
+/// Internal re-exports for `#[derive(GtagEvent)]`-generated code. Not public API.
+#[doc(hidden)]
+pub mod __private {
+    pub use serde_json;
+}
 
 pub mod prelude {
     pub use crate::config::GtagConfig;
@@ -59,6 +68,7 @@ pub mod prelude {
         consume_gtag_context, provide_gtag_context, use_gtag_context, use_gtag_context_provider,
         use_gtag_context_provider_with, UseGtagContext,
     };
+    pub use crate::GtagEvent; // trait and derive macro
     #[cfg(feature = "router")]
     pub use crate::router::use_gtag_page_view;
     pub use crate::value::GtagValue;

--- a/packages/dioxus-gtag/src/lib.rs
+++ b/packages/dioxus-gtag/src/lib.rs
@@ -1,0 +1,65 @@
+//! Google Analytics 4 (gtag.js) integration for Dioxus.
+//!
+//! Provide the context once at the App root, then send events from anywhere:
+//!
+//! ```rust,ignore
+//! use dioxus::prelude::*;
+//! use dioxus_gtag::*;
+//!
+//! #[component]
+//! pub fn App() -> Element {
+//!     use_gtag_context_provider("G-XXXXXXXXXX");
+//!     rsx! { Router::<Route> {} }
+//! }
+//!
+//! #[component]
+//! pub fn BuyButton() -> Element {
+//!     rsx! {
+//!         button {
+//!             onclick: move |_| {
+//!                 consume_gtag_context()
+//!                     .event("purchase", &[("currency", "KRW".into()), ("value", 12000.into())]);
+//!             },
+//!             "Buy"
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! The provider injects gtag.js through `document::eval`, so it works on web
+//! and desktop (webview) and is a no-op during SSR — no `index.html` edits and
+//! no `#[cfg]` at call sites. Events fired before gtag.js is bootstrapped are
+//! buffered and flushed on initialization.
+//!
+//! With the `router` feature, [`use_gtag_page_view`] tracks route changes
+//! automatically.
+
+mod config;
+mod consent;
+mod context;
+mod js;
+#[cfg(feature = "router")]
+mod router;
+mod value;
+
+pub use config::GtagConfig;
+pub use consent::{ConsentStatus, ConsentUpdate};
+pub use context::{
+    consume_gtag_context, provide_gtag_context, use_gtag_context, use_gtag_context_provider,
+    use_gtag_context_provider_with, UseGtagContext,
+};
+#[cfg(feature = "router")]
+pub use router::use_gtag_page_view;
+pub use value::GtagValue;
+
+pub mod prelude {
+    pub use crate::config::GtagConfig;
+    pub use crate::consent::{ConsentStatus, ConsentUpdate};
+    pub use crate::context::{
+        consume_gtag_context, provide_gtag_context, use_gtag_context, use_gtag_context_provider,
+        use_gtag_context_provider_with, UseGtagContext,
+    };
+    #[cfg(feature = "router")]
+    pub use crate::router::use_gtag_page_view;
+    pub use crate::value::GtagValue;
+}

--- a/packages/dioxus-gtag/src/router.rs
+++ b/packages/dioxus-gtag/src/router.rs
@@ -1,0 +1,25 @@
+use dioxus::prelude::*;
+
+use crate::context::use_gtag_context;
+
+/// Hook — sends a `page_view` on every route change (including the initial
+/// route). Call it once from the root layout, inside the `Router`:
+///
+/// ```rust,ignore
+/// #[component]
+/// pub fn RootLayout() -> Element {
+///     use_gtag_page_view();
+///     rsx! { Outlet::<Route> {} }
+/// }
+/// ```
+///
+/// Requires the `router` feature. The provider's gtag config keeps
+/// `send_page_view: false` by default, so this does not double-count.
+pub fn use_gtag_page_view() {
+    let ctx = use_gtag_context();
+    use_effect(move || {
+        // full_route_string subscribes this effect to route changes.
+        let route = dioxus::router::router().full_route_string();
+        ctx.page_view(&route, None);
+    });
+}

--- a/packages/dioxus-gtag/src/value.rs
+++ b/packages/dioxus-gtag/src/value.rs
@@ -1,0 +1,81 @@
+/// A parameter value accepted by gtag event/config calls.
+///
+/// Use the `From` impls to build values inline:
+///
+/// ```rust
+/// use dioxus_gtag::GtagValue;
+///
+/// let params: &[(&str, GtagValue)] = &[
+///     ("currency", "KRW".into()),
+///     ("value", 12000.into()),
+///     ("logged_in", true.into()),
+/// ];
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub enum GtagValue {
+    String(String),
+    Int(i64),
+    Number(f64),
+    Bool(bool),
+}
+
+impl GtagValue {
+    pub(crate) fn to_json(&self) -> serde_json::Value {
+        match self {
+            GtagValue::String(s) => serde_json::Value::String(s.clone()),
+            GtagValue::Int(i) => serde_json::Value::from(*i),
+            GtagValue::Number(n) => serde_json::Value::from(*n),
+            GtagValue::Bool(b) => serde_json::Value::Bool(*b),
+        }
+    }
+}
+
+impl From<&str> for GtagValue {
+    fn from(v: &str) -> Self {
+        GtagValue::String(v.to_string())
+    }
+}
+
+impl From<String> for GtagValue {
+    fn from(v: String) -> Self {
+        GtagValue::String(v)
+    }
+}
+
+impl From<i32> for GtagValue {
+    fn from(v: i32) -> Self {
+        GtagValue::Int(v as i64)
+    }
+}
+
+impl From<i64> for GtagValue {
+    fn from(v: i64) -> Self {
+        GtagValue::Int(v)
+    }
+}
+
+impl From<u32> for GtagValue {
+    fn from(v: u32) -> Self {
+        GtagValue::Int(v as i64)
+    }
+}
+
+impl From<f64> for GtagValue {
+    fn from(v: f64) -> Self {
+        GtagValue::Number(v)
+    }
+}
+
+impl From<bool> for GtagValue {
+    fn from(v: bool) -> Self {
+        GtagValue::Bool(v)
+    }
+}
+
+pub(crate) fn params_to_json(params: &[(&str, GtagValue)]) -> serde_json::Value {
+    let mut map = serde_json::Map::new();
+    for (key, value) in params {
+        map.insert(key.to_string(), value.to_json());
+    }
+    serde_json::Value::Object(map)
+}

--- a/packages/dioxus-gtag/tests/derive_event.rs
+++ b/packages/dioxus-gtag/tests/derive_event.rs
@@ -1,0 +1,49 @@
+use dioxus_gtag::GtagEvent;
+
+#[derive(GtagEvent)]
+#[gtag(name = "purchase")]
+struct Purchase {
+    value: f64,
+    currency: String,
+    #[gtag(rename = "item_id")]
+    sku: String,
+    #[gtag(skip)]
+    internal: bool,
+}
+
+#[derive(GtagEvent)]
+struct QuizSubmitted {
+    score: i64,
+}
+
+#[derive(GtagEvent)]
+struct SignOut;
+
+#[test]
+fn derive_with_name_rename_and_skip() {
+    let event = Purchase {
+        value: 12000.0,
+        currency: "KRW".to_string(),
+        sku: "SKU_1".to_string(),
+        internal: true,
+    };
+    assert_eq!(event.event_name(), "purchase");
+    assert_eq!(
+        event.params(),
+        serde_json::json!({ "value": 12000.0, "currency": "KRW", "item_id": "SKU_1" })
+    );
+}
+
+#[test]
+fn event_name_defaults_to_snake_case() {
+    let event = QuizSubmitted { score: 42 };
+    assert_eq!(event.event_name(), "quiz_submitted");
+    assert_eq!(event.params(), serde_json::json!({ "score": 42 }));
+}
+
+#[test]
+fn unit_struct_has_empty_params() {
+    let event = SignOut;
+    assert_eq!(event.event_name(), "sign_out");
+    assert_eq!(event.params(), serde_json::json!({}));
+}


### PR DESCRIPTION
## Summary

Adds `packages/dioxus-gtag`, a Google Analytics 4 (gtag.js) integration for Dioxus apps, following the four-function context convention used across our Dioxus codebases:

| Function | Hook? | Call site |
|----------|-------|-----------|
| `use_gtag_context_provider(id)` / `use_gtag_context_provider_with(config)` | Yes | App root |
| `use_gtag_context()` | Yes | Component/hook body |
| `consume_gtag_context()` | No | `spawn`, event closures |
| `provide_gtag_context(ctx)` | No | Conditional provides, tests |

The context struct is `UseGtagContext` with `#[derive(Clone, Copy, DioxusController)]` and `&self` methods.

## Design highlights

- **No `index.html` edits**: the provider bootstraps gtag.js via `document::eval` inside a `use_effect`, so initialization only runs on the client — SSR/fullstack safe, and works on both web and desktop (webview) without `#[cfg]` at call sites.
- **No lost events**: calls made before gtag.js is bootstrapped are buffered and flushed on initialization.
- **No double counting**: gtag is configured with `send_page_view: false` by default; the optional `router` feature provides `use_gtag_page_view()` which sends `page_view` on every route change via `RouterContext::full_route_string()`.
- **Typed events**: the `dioxus-gtag-macro` crate provides `#[derive(GtagEvent)]` — event name defaults to the snake_case struct name (`#[gtag(name)]` to override), fields become serde-serialized params with `#[gtag(rename)]`/`#[gtag(skip)]`, sent via `gtag.send(&event)`.
- **Privacy controls**: Consent Mode v2 (`ConsentUpdate`, default + update), `user_id`/user properties, and a runtime opt-in/opt-out toggle backed by GA's `ga-disable-{id}` kill switch. With `GtagConfig::enabled(false)`, nothing is loaded until the user opts in.
- **Injection-safe JS**: all dynamic strings are embedded via `serde_json` serialization; snippet builders live in a pure `js` module with unit tests.

## Usage

```rust
#[component]
pub fn App() -> Element {
    use_gtag_context_provider("G-XXXXXXXXXX");
    rsx! { Router::<Route> {} }
}

// event handler (non-hook context)
onclick: move |_| {
    consume_gtag_context()
        .event("purchase", &[("currency", "KRW".into()), ("value", 12000.into())]);
}

// typed event
#[derive(GtagEvent)]
#[gtag(name = "purchase")]
struct Purchase { value: f64, currency: String }
gtag.send(&Purchase { value: 12000.0, currency: "KRW".into() });
```

See `packages/dioxus-gtag/README.md` for the full guide.

## Notes

- Targets dioxus 0.7 with `default-features = false, features = ["signals", "hooks", "document"]`; the `router` feature is opt-in.
- `Cargo.lock` updated (new package deps; `futures-channel` bumped to 0.3.32, required by dioxus-core 0.7).
- Also fixes pre-existing by-macros test compilation broken since the workspace strip-down (`13d21b7`): the removed `by-types`/`by-axum`/`rest-api` dev-dependencies are restored as git dependencies pinned to the last pre-removal commit (the removed `by-types` 0.3.9 was never published; crates.io only has 0.3.7). Longer-term fix is publishing `by-types` 0.3.9 or pruning the test fixtures.

## Test plan

- All three CI jobs green (`build`, `non-server-feature`, `server-feature`)
- `cargo test -p dioxus-gtag --features router`: 7 unit tests + 3 derive integration tests + doctests pass
- `cargo clippy -p dioxus-gtag -p dioxus-gtag-macro` clean; `RUSTFLAGS="-D warnings" make build` passes

https://claude.ai/code/session_01SrDr4G2Tw5fG9VfukGhsCU